### PR TITLE
fix/webhooks-to-use-host-network

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.10.0
+version: 0.10.0-alpha1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.10.0-alpha1
+version: 0.10.0-alpha2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.9.1
+version: 0.10.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.10.0-alpha5
+version: 0.10.0-alpha6

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.10.0-alpha2
+version: 0.10.0-alpha3

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.10.0-alpha6
+version: 0.10.0-alpha7

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.10.0-alpha3
+version: 0.10.0-alpha4

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.10.0-alpha7
+version: 0.10.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.10.0-alpha4
+version: 0.10.0-alpha5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.10.0-alpha4](https://img.shields.io/badge/Version-0.10.0--alpha4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.10.0-alpha5](https://img.shields.io/badge/Version-0.10.0--alpha5-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.10.0-alpha5](https://img.shields.io/badge/Version-0.10.0--alpha5-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.10.0-alpha6](https://img.shields.io/badge/Version-0.10.0--alpha6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.10.0-alpha6](https://img.shields.io/badge/Version-0.10.0--alpha6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.10.0-alpha7](https://img.shields.io/badge/Version-0.10.0--alpha7-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.10.0-alpha1](https://img.shields.io/badge/Version-0.10.0--alpha1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.10.0-alpha2](https://img.shields.io/badge/Version-0.10.0--alpha2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.10.0-alpha2](https://img.shields.io/badge/Version-0.10.0--alpha2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.10.0-alpha3](https://img.shields.io/badge/Version-0.10.0--alpha3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.10.0-alpha3](https://img.shields.io/badge/Version-0.10.0--alpha3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.10.0-alpha4](https://img.shields.io/badge/Version-0.10.0--alpha4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.10.0-alpha1](https://img.shields.io/badge/Version-0.10.0--alpha1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -10,7 +10,7 @@ spec:
     namespace: glueops-core-cert-manager
   source:
     path: ''
-    repoURL: 'https://helm.gpkg.io/platform'
+    repoURL: 'https://incubating-helm.gpkg.io/platform'
     targetRevision: 0.7.0-alpha1
     helm:
       skipCrds: true

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -10,8 +10,8 @@ spec:
     namespace: glueops-core-cert-manager
   source:
     path: ''
-    repoURL: 'https://incubating-helm.gpkg.io/platform'
-    targetRevision: 0.7.0-alpha1
+    repoURL: 'https://helm.gpkg.io/platform'
+    targetRevision: 0.7.0
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://helm.gpkg.io/platform'
-    targetRevision: 0.6.2
+    targetRevision: 0.7.0-alpha1
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -9,9 +9,9 @@ spec:
     name: "in-cluster"
     namespace: glueops-core-external-secrets
   source:
-    repoURL: 'https://helm.gpkg.io/platform'
+    repoURL: 'https://incubating-helm.gpkg.io/platform'
     chart: glueops-external-secrets
-    targetRevision: 0.2.0
+    targetRevision: 0.3.0-alpha1
     helm:
       skipCrds: true
   project: glueops-core

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -9,7 +9,7 @@ spec:
     name: "in-cluster"
     namespace: glueops-core-external-secrets
   source:
-    repoURL: 'https://incubating-helm.gpkg.io/platform'
+    repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-external-secrets
     targetRevision: 0.3.0
     helm:

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: 'https://incubating-helm.gpkg.io/platform'
     chart: glueops-external-secrets
-    targetRevision: 0.3.0-alpha1
+    targetRevision: 0.3.0
     helm:
       skipCrds: true
   project: glueops-core

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -53,7 +53,8 @@ spec:
             KubePodNotReady: true
         prometheusOperator:
           hostNetwork: true
-          internalPort: 10754
+          tls:
+            internalPort: 10754
         prometheus: 
           prometheusSpec:
             ruleSelector: {}

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -51,6 +51,8 @@ spec:
         defaultRules:
           disabled:
             KubePodNotReady: true
+        prometheusOperator:
+          hostNetwork: true
         prometheus: 
           prometheusSpec:
             ruleSelector: {}
@@ -63,6 +65,7 @@ spec:
             podMonitorNamespaceSelector: {}
             podMonitorSelectorNilUsesHelmValues: false
             logLevel: debug
+            hostNetwork: true
         grafana:
           adminPassword: "{{ .Values.grafana.admin_password }}"
           ingress:

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -53,6 +53,7 @@ spec:
             KubePodNotReady: true
         prometheusOperator:
           hostNetwork: true
+          internalPort: 10254
         prometheus: 
           prometheusSpec:
             ruleSelector: {}

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -53,7 +53,7 @@ spec:
             KubePodNotReady: true
         prometheusOperator:
           hostNetwork: true
-          internalPort: 10254
+          internalPort: 10754
         prometheus: 
           prometheusSpec:
             ruleSelector: {}

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -22,6 +22,11 @@ spec:
           value: 'false'
       values: |-
         controller:
+          hostNetwork: true
+          hostPort:
+            ports:
+              http: 10752
+              https: 10753
           config:
             # https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/log-format.md
             # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/


### PR DESCRIPTION
Because we are using calico in VxLan mode we need to have the webhooks run on the hostnetwork. It's a documented issue as the EKS control plane nodes won't be able to talk to the admission (mutating/validation) webhooks unless they are on the host network. These changes *should* work in GCP but haven't been tested yet.

Ports being used:
certmanager - 10750
externalsecrets - 10751
nginx - http- 10752
nginx - https - 10753
kube-prometheus-stack - 10754

For some reason if we don't specify a port it uses 10250 which conflicts with the kublet port. So I just added 500 and incremented by 1 in the order I came across the issues.
