### PR TITLE
feat: monthly updates (#27)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.12.0
+version: 0.13.0

--- a/templates/application-backup-hashicorp-vault.yaml
+++ b/templates/application-backup-hashicorp-vault.yaml
@@ -26,7 +26,7 @@ spec:
       - name: cron_expression
         value: "{{ .Values.glueops_backups.vault.cron_expression }}"
     repoURL: https://helm.gpkg.io/platform
-    targetRevision: 0.2.1
+    targetRevision: 0.2.2
   syncPolicy:
     automated:
       prune: true

--- a/templates/application-cert-manager-crd.yaml
+++ b/templates/application-cert-manager-crd.yaml
@@ -9,7 +9,7 @@ spec:
     name: "in-cluster"
     namespace: glueops-core-cert-manager
   source:
-    path: v1.11.1/
+    path: v1.11.2/
     repoURL: 'https://github.com/GlueOps/cert-manager-crds'
     targetRevision: HEAD
   project: glueops-core

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://helm.gpkg.io/platform'
-    targetRevision: 0.7.0
+    targetRevision: 0.7.1
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://charts.bitnami.com/bitnami'
-    targetRevision: 6.18.0
+    targetRevision: 6.20.1
     chart: external-dns
     helm:
       parameters:

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -24,7 +24,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/crds/
-    targetRevision: kube-prometheus-stack-45.17.0
+    targetRevision: kube-prometheus-stack-45.27.2
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -23,7 +23,7 @@ spec:
       limit: 5
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
-    targetRevision: 45.17.0
+    targetRevision: 45.27.2
     helm:
       skipCrds: true
       values: |-

--- a/templates/application-loki-log-exporter-to-s3.yaml
+++ b/templates/application-loki-log-exporter-to-s3.yaml
@@ -28,7 +28,7 @@ spec:
       - name: loki_addr
         value: "http://loki-gateway.glueops-core-loki.svc.cluster.local"
     repoURL: https://helm.gpkg.io/platform
-    targetRevision: 0.1.0
+    targetRevision: 0.1.1
   syncPolicy:
     automated:
       prune: true

--- a/templates/application-loki.yaml
+++ b/templates/application-loki.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://grafana.github.io/helm-charts'
-    targetRevision: 5.2.0
+    targetRevision: 5.5.1
     helm:
       parameters:
         - name: loki.auth_enabled

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://helm.gpkg.io/platform'
-    targetRevision: v4.10.0
+    targetRevision: v4.10.3
     helm:
       parameters:
         - name: replicas

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://kubernetes.github.io/ingress-nginx'
-    targetRevision: v4.6.0
+    targetRevision: v4.6.1
     helm:
       parameters:
         - name: controller.service.externalTrafficPolicy

--- a/templates/application-pomerium.yaml
+++ b/templates/application-pomerium.yaml
@@ -14,7 +14,7 @@ spec:
       - pomerium/ingress-controller:sha-4727f17
     path: .
     repoURL: https://github.com/GlueOps/platform-kustomize-pomerium.git
-    targetRevision: v0.1.0
+    targetRevision: v0.2.0
   project: glueops-core
   syncPolicy:
     syncOptions:

--- a/templates/application-promtail.yaml
+++ b/templates/application-promtail.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://grafana.github.io/helm-charts'
-    targetRevision: 6.10.0
+    targetRevision: 6.11.2
     chart: promtail
     helm:
       parameters:

--- a/templates/application-pull-request-bot.yaml
+++ b/templates/application-pull-request-bot.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     path: kubernetes/
     repoURL: 'https://github.com/GlueOps/pull-request-bot.git'
-    targetRevision: v0.4.0
+    targetRevision: v0.5.1
   project: glueops-core
   syncPolicy:
     syncOptions:

--- a/templates/application-pull-request-bot.yaml
+++ b/templates/application-pull-request-bot.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     path: kubernetes/
     repoURL: 'https://github.com/GlueOps/pull-request-bot.git'
-    targetRevision: v0.5.1
+    targetRevision: v0.5.2
   project: glueops-core
   syncPolicy:
     syncOptions:

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -25,7 +25,7 @@ spec:
           enabled: false
         server:
           image:
-            tag: 1.13.1
+            tag: 1.13.2
           ingress:
               activeService: false
               ingressClassName: public-authenticated


### PR DESCRIPTION
feat: update backup-hashicorp-vault from 0.2.1 -> 0.2.2
feat: update cert-manager from 0.11.1 -> 0.11.2
feat: update external-dns from bitnami version 6.18.0 -> 6.20.1
feat: update kube-prometheus-stack from 45.17.0 -> 45.27.2
feat: update loki log exporter from 0.1.0 -> 0.1.1
feat: update loki helm chart from 5.2.0 -> 5.5.1
feat: update metacontroller from 4.10.0 -> 4.10.3
feat: update ingress-nginx from 4.6.0 -> 4.6.1
feat: update pomerium from 0.1.0 -> 0.2.0
feat: update promtail from 6.10.0 -> 6.11.2
feat: update pull-request-bot from 0.4.0 -> 0.5.2
feat: update vault server from 1.13.1 -> 1.13.2
chore: bump glueops-platform helm chart version