### PR TITLE
chore: bump grafana dashboard to v0.8.0

### DIFF
--- a/templates/application-glueops-grafana-dashboards.yaml
+++ b/templates/application-glueops-grafana-dashboards.yaml
@@ -24,6 +24,6 @@ spec:
   source:
     path: ''
     repoURL: 'https://helm.gpkg.io/platform'
-    targetRevision: 0.7.0
+    targetRevision: 0.8.0
     chart: glueops-grafana-dashboards
   project: glueops-core


### PR DESCRIPTION
chore: bump grafana dashboard to v0.8.0