### PR TITLE
feat: adding resources finalizer to improve cleanup when removing argocd applications

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.16.0-alpha2
+version: 0.16.0-alpha3

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.16.0-alpha4
+version: 0.16.0-alpha5

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.16.0-alpha6
+version: 0.16.0-alpha7

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.16.0-alpha5
+version: 0.16.0-alpha6

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.16.0-alpha3
+version: 0.16.0-alpha4

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.16.0-alpha7
+version: 0.16.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.15.0
+version: 0.16.0-alpha1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.16.0-alpha1
+version: 0.16.0-alpha2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.16.0-alpha1](https://img.shields.io/badge/Version-0.16.0--alpha1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.16.0-alpha2](https://img.shields.io/badge/Version-0.16.0--alpha2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 
@@ -40,6 +40,12 @@ This chart deploys the GlueOps Platform
 | glueops_backups.vault.company_key | string | `"placeholder_tenant_key"` |  |
 | grafana.admin_password | string | `"placeholder_grafana_admin_password"` | Default admin password. CHANGE THIS!!!! |
 | grafana.github_other_org_names | string | `"placeholder_tenant_github_org_name"` |  |
+| host_network.cert_manager.webhook_secure_port | int | `10750` |  |
+| host_network.enabled | bool | `true` |  |
+| host_network.external_secrets.webhook_port | int | `10751` |  |
+| host_network.kube_pometheus_stack.prometheusOperator.tls.internal_port | int | `10754` |  |
+| host_network.nginx_public.controller.host_port.ports.http | int | `10752` |  |
+| host_network.nginx_public.controller.host_port.ports.https | int | `10753` |  |
 | loki.aws_accessKey | string | `"placeholder_loki_aws_access_key"` | Part of `loki_s3_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | loki.aws_region | string | `"placeholder_aws_region"` | Should be the same `primary_region` you used in: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | loki.aws_secretKey | string | `"placeholder_loki_aws_secret_key"` | Part of `loki_s3_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.16.0-alpha3](https://img.shields.io/badge/Version-0.16.0--alpha3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.16.0-alpha4](https://img.shields.io/badge/Version-0.16.0--alpha4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 
@@ -41,7 +41,7 @@ This chart deploys the GlueOps Platform
 | grafana.admin_password | string | `"placeholder_grafana_admin_password"` | Default admin password. CHANGE THIS!!!! |
 | grafana.github_other_org_names | string | `"placeholder_tenant_github_org_name"` |  |
 | host_network.cert_manager.webhook_secure_port | int | `10750` |  |
-| host_network.enabled | bool | `true` |  |
+| host_network.enabled | string | `"true"` |  |
 | host_network.external_secrets.webhook_port | int | `10751` |  |
 | host_network.kube_pometheus_stack.prometheusOperator.tls.internal_port | int | `10754` |  |
 | host_network.nginx_public.controller.host_port.ports.http | int | `10752` |  |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.16.0-alpha4](https://img.shields.io/badge/Version-0.16.0--alpha4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.16.0-alpha5](https://img.shields.io/badge/Version-0.16.0--alpha5-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.16.0-alpha1](https://img.shields.io/badge/Version-0.16.0--alpha1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.16.0-alpha6](https://img.shields.io/badge/Version-0.16.0--alpha6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.16.0-alpha7](https://img.shields.io/badge/Version-0.16.0--alpha7-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 
@@ -41,7 +41,7 @@ This chart deploys the GlueOps Platform
 | grafana.admin_password | string | `"placeholder_grafana_admin_password"` | Default admin password. CHANGE THIS!!!! |
 | grafana.github_other_org_names | string | `"placeholder_tenant_github_org_name"` |  |
 | host_network.cert_manager.webhook_secure_port | int | `10750` |  |
-| host_network.enabled | string | `"true"` |  |
+| host_network.enabled | bool | `true` |  |
 | host_network.external_secrets.webhook_port | int | `10751` |  |
 | host_network.kube_pometheus_stack.prometheusOperator.tls.internal_port | int | `10754` |  |
 | host_network.nginx_public.controller.host_port.ports.http | int | `10752` |  |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.16.0-alpha2](https://img.shields.io/badge/Version-0.16.0--alpha2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.16.0-alpha3](https://img.shields.io/badge/Version-0.16.0--alpha3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.16.0-alpha5](https://img.shields.io/badge/Version-0.16.0--alpha5-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.16.0-alpha6](https://img.shields.io/badge/Version-0.16.0--alpha6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/main.tf
+++ b/main.tf
@@ -103,6 +103,12 @@ variable "this_is_development" {
   description = "Determines whether the cluster is a development cluster or deployed in a customer environment."
 }
 
+variable "host_network_enabled" {
+  type        = bool
+  description = "Determines whether or not to use hostNetwork mode."
+}
+  
+
 
 data "local_file" "platform_values_template" {
   filename = "${path.module}/values.yaml"
@@ -149,11 +155,12 @@ variable "github_tenant_app_b64enc_private_key" {
 
 
 output "helm_values" {
-  value = replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(
+  value = replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(
     replace(
       data.local_file.platform_values_template.content,
     "placeholder_tenant_key", var.tenant_key),
     "placeholder_this_is_development", var.this_is_development),
+    "placeholder_enable_host_network", var.host_network_enabled),
     "placeholder_cluster_environment", var.cluster_environment),
     "placeholder_glueops_root_domain", var.glueops_root_domain),
     "placeholder_opsgenie_api_key", var.opsgenie_api_key),

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: glueops-backups-and-exports
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-cert-manager-crd.yaml
+++ b/templates/application-cert-manager-crd.yaml
@@ -4,6 +4,8 @@ metadata:
   name: cert-manager-crds
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -4,6 +4,8 @@ metadata:
   name: cert-manager
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -47,4 +47,4 @@ spec:
         - name: cert-manager.webhook.hostNetwork
           value: "{{ .Values.host_network.enabled }}"
         - name: cert-manager.webhook.securePort
-          value: {{ .Values.host_network.cert_manager.webhook_secure_port }}
+          value: "{{ .Values.host_network.cert_manager.webhook_secure_port }}"

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -44,3 +44,7 @@ spec:
           value: "true"
         - name: cert-manager.prometheus.servicemonitor.enabled
           value: "true"
+        - name: cert-manager.webhook.hostNetwork
+          value: {{ .Values.host_network.enabled }}
+        - name: cert-manager.webhook.securePort
+          value: {{ .Values.host_network.cert_manager.webhook_secure_port }}

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -45,6 +45,6 @@ spec:
         - name: cert-manager.prometheus.servicemonitor.enabled
           value: "true"
         - name: cert-manager.webhook.hostNetwork
-          value: {{ .Values.host_network.enabled }}
+          value: "{{ .Values.host_network.enabled }}"
         - name: cert-manager.webhook.securePort
           value: {{ .Values.host_network.cert_manager.webhook_secure_port }}

--- a/templates/application-dex.yaml
+++ b/templates/application-dex.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "2"
   name: glueops-dex
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -4,6 +4,8 @@ metadata:
   name: external-dns
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -44,7 +44,7 @@ spec:
         - name: aws.preferCNAME
           value: "true"
         - name: txtPrefix
-          value: extdnsk8s
+          value: "extdns-"
         - name: metrics.enabled
           value: "true"
         - name: metrics.serviceMonitor.enabled

--- a/templates/application-external-secrets-crd.yaml
+++ b/templates/application-external-secrets-crd.yaml
@@ -4,6 +4,8 @@ metadata:
   name: external-secrets-crds
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -33,5 +33,5 @@ spec:
         - name: external-secrets.webhook.hostNetwork
           value: "{{ .Values.host_network.enabled }}"
         - name: external-secrets.webhook.port
-          value: {{ .Values.host_network.external_secrets.webhook_port }}
+          value: "{{ .Values.host_network.external_secrets.webhook_port }}"
           

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -29,3 +29,9 @@ spec:
     targetRevision: 0.3.2
     helm:
       skipCrds: true
+      parameters:
+        - name: external-secrets.webhook.hostNetwork
+          value: {{ .Values.host_network.enabled }}
+        - name: external-secrets.webhook.port
+          value: {{ .Values.host_network.external_secrets.webhook_port }}
+          

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -4,6 +4,8 @@ metadata:
   name: external-secrets
   annotations:
     argocd.argoproj.io/sync-wave: "5"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -31,7 +31,7 @@ spec:
       skipCrds: true
       parameters:
         - name: external-secrets.webhook.hostNetwork
-          value: {{ .Values.host_network.enabled }}
+          value: "{{ .Values.host_network.enabled }}"
         - name: external-secrets.webhook.port
           value: {{ .Values.host_network.external_secrets.webhook_port }}
           

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -6,6 +6,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "10"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-glueops-grafana-dashboards.yaml
+++ b/templates/application-glueops-grafana-dashboards.yaml
@@ -26,4 +26,4 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-grafana-dashboards
-    targetRevision: 0.8.1
+    targetRevision: 0.8.2

--- a/templates/application-glueops-grafana-dashboards.yaml
+++ b/templates/application-glueops-grafana-dashboards.yaml
@@ -4,6 +4,8 @@ metadata:
   name: glueops-grafana-dashboards
   annotations:
     argocd.argoproj.io/sync-wave: "3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kube-prometheus-stack-crds
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -58,9 +58,9 @@ spec:
           disabled:
             KubePodNotReady: true
         prometheusOperator:
-          hostNetwork: true
+          hostNetwork: {{ .Values.host_network.enabled }}
           tls:
-            internalPort: 10754
+            internalPort: {{ .Values.host_network.kube_pometheus_stack.prometheusOperator.tls.internal_port }}
         prometheus: 
           prometheusSpec:
             replicas: 2
@@ -82,7 +82,7 @@ spec:
                   resources:
                     requests:
                       storage: {{ .Values.prometheus.volume_claim_storage_request}}Gi
-            hostNetwork: true
+            hostNetwork: {{ .Values.host_network.enabled }}
         grafana:
           adminPassword: "{{ .Values.grafana.admin_password }}"
           ingress:

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kube-prometheus-stack
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-loki-alert-group-controller.yaml
+++ b/templates/application-loki-alert-group-controller.yaml
@@ -4,6 +4,8 @@ metadata:
   name: loki-alert-group-controller
   annotations:
     argocd.argoproj.io/sync-wave: "3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-loki.yaml
+++ b/templates/application-loki.yaml
@@ -4,6 +4,8 @@ metadata:
   name: loki
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -4,6 +4,8 @@ metadata:
   name: metacontroller
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -40,8 +40,8 @@ spec:
           hostNetwork: {{ .Values.host_network.enabled }}
           hostPort:
             ports:
-              http: {{ .Values.nginx_public.controller.host_port.ports.http }}
-              https: {{ .Values.nginx_public.controller.host_port.ports.https }}
+              http: {{ .Values.host_network.nginx_public.controller.host_port.ports.http }}
+              https: {{ .Values.host_network.nginx_public.controller.host_port.ports.https }}
           config:
             # https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/log-format.md
             # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -37,11 +37,11 @@ spec:
           value: 'false'
       values: |-
         controller:
-          hostNetwork: true
+          hostNetwork: {{ .Values.host_network.enabled }}
           hostPort:
             ports:
-              http: 10752
-              https: 10753
+              http: {{ .Values.nginx_public.controller.host_port.ports.http }}
+              https: {{ .Values.nginx_public.controller.host_port.ports.https }}
           config:
             # https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/log-format.md
             # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -4,6 +4,8 @@ metadata:
   name: public-ingress-nginx
   annotations:
     argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-pomerium-post-deploy.yaml
+++ b/templates/application-pomerium-post-deploy.yaml
@@ -4,6 +4,8 @@ metadata:
   name: glueops-pomerium-post-deploy
   annotations:
     argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-pomerium.yaml
+++ b/templates/application-pomerium.yaml
@@ -4,6 +4,8 @@ metadata:
   name: glueops-pomerium
   annotations:
     argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-promtail.yaml
+++ b/templates/application-promtail.yaml
@@ -4,6 +4,8 @@ metadata:
   name: promtail
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-pull-request-bot.yaml
+++ b/templates/application-pull-request-bot.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: glueops-pull-request-bot
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-strimzi.yaml
+++ b/templates/application-strimzi.yaml
@@ -4,6 +4,8 @@ metadata:
   name: strimzi-operator
   annotations:
     argocd.argoproj.io/sync-wave: "4"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-tenant-application-stack.yaml
+++ b/templates/application-tenant-application-stack.yaml
@@ -4,6 +4,8 @@ metadata:
   name: tenant-application-stack 
   annotations:
     argocd.argoproj.io/sync-wave: "20"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-vault-prerequisites.yaml
+++ b/templates/application-vault-prerequisites.yaml
@@ -4,6 +4,8 @@ metadata:
   name: vault-prerequisites
   annotations:
     argocd.argoproj.io/sync-wave: "3"  
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -4,6 +4,8 @@ metadata:
   name: vault
   annotations:
     argocd.argoproj.io/sync-wave: "4"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@
 development_mode_enabled: placeholder_this_is_development
 
 host_network:
-  enabled: "true"
+  enabled: true
   external_secrets:
     webhook_port: 10751
   cert_manager:

--- a/values.yaml
+++ b/values.yaml
@@ -2,21 +2,21 @@
 development_mode_enabled: placeholder_this_is_development
 
 host_network:
-  enabled: true
+  enabled: placeholder_enable_host_network
   external_secrets:
-    webhook_port: 10751
+    webhook_port: 49250
   cert_manager:
-    webhook_secure_port: 10750
+    webhook_secure_port: 49260
   nginx_public:
     controller:
       host_port:
         ports:
-          http: 10752
-          https: 10753
+          http: 49270
+          https: 49271
   kube_pometheus_stack:
     prometheusOperator:
       tls:
-        internal_port: 10754
+        internal_port: 49280
 
 
 # -- The Route53 subdomain for the services on your cluster. It will be used as the suffix url for argocd, grafana, vault, and any other services that come out of the box in the glueops platform. Note: you need to create this before using this repo as this repo does not provision DNS Zones for you.

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,24 @@
 # @ignored
 development_mode_enabled: placeholder_this_is_development
 
+host_network:
+  enabled: true
+  external_secrets:
+    webhook_port: 10751
+  cert_manager:
+    webhook_secure_port: 10750
+  nginx_public:
+    controller:
+      host_port:
+        ports:
+          http: 10752
+          https: 10753
+  kube_pometheus_stack:
+    prometheusOperator:
+      tls:
+        internal_port: 10754
+
+
 # -- The Route53 subdomain for the services on your cluster. It will be used as the suffix url for argocd, grafana, vault, and any other services that come out of the box in the glueops platform. Note: you need to create this before using this repo as this repo does not provision DNS Zones for you.
 # This is the domain you created through: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites
 captain_domain: placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain

--- a/values.yaml
+++ b/values.yaml
@@ -4,19 +4,19 @@ development_mode_enabled: placeholder_this_is_development
 host_network:
   enabled: placeholder_enable_host_network
   external_secrets:
-    webhook_port: 49250
+    webhook_port: 45010
   cert_manager:
-    webhook_secure_port: 49260
+    webhook_secure_port: 45020
   nginx_public:
     controller:
       host_port:
         ports:
-          http: 49270
-          https: 49271
+          http: 45030
+          https: 45031
   kube_pometheus_stack:
     prometheusOperator:
       tls:
-        internal_port: 49280
+        internal_port: 45040
 
 
 # -- The Route53 subdomain for the services on your cluster. It will be used as the suffix url for argocd, grafana, vault, and any other services that come out of the box in the glueops platform. Note: you need to create this before using this repo as this repo does not provision DNS Zones for you.

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@
 development_mode_enabled: placeholder_this_is_development
 
 host_network:
-  enabled: true
+  enabled: "true"
   external_secrets:
     webhook_port: 10751
   cert_manager:


### PR DESCRIPTION
fix: added resources-finalizer.argocd.argoproj.io to all argocd applications so that things get cleaned up whenever things are removed.
fix: picked better port numbers for the various services that run on hostNetwork. ChatGPT recommended the ranges I picked
fix: added hostNetwork enabled flag so that we can deploy to clouds like digital ocean