### PR TITLE
Fix/ingress nginx scaling

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.20.0
+version: 0.21.0-alpha1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.21.0-alpha1](https://img.shields.io/badge/Version-0.21.0--alpha1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/templates/application-dex.yaml
+++ b/templates/application-dex.yaml
@@ -34,7 +34,9 @@ spec:
           tag: v2.37.0
         ingress:
           enabled: true
-          className: "public"
+          className: "public-authenticated"
+          annotations:
+            ingress.pomerium.io/allow_public_unauthenticated_access: 'true'
           hosts:
             - host: dex.{{ .Values.captain_domain }}
               paths:

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -28,20 +28,12 @@ spec:
     chart: ingress-nginx
     targetRevision: v4.7.1
     helm:
-      parameters:
-        - name: controller.service.externalTrafficPolicy
-          value: "Local"
-        - name: controller.service.type
-          value: LoadBalancer
-        - name: controller.hostPort.enabled
-          value: 'false'
       values: |-
         controller:
-          hostNetwork: {{ .Values.host_network.enabled }}
-          hostPort:
-            ports:
-              http: {{ .Values.host_network.nginx_public.controller.host_port.ports.http }}
-              https: {{ .Values.host_network.nginx_public.controller.host_port.ports.https }}
+          admissionWebhooks:
+            enabled: false
+          replicaCount: 4
+          maxUnavailable: 1
           config:
             # https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/log-format.md
             # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
@@ -89,6 +81,8 @@ spec:
           service:
             annotations:
               external-dns.alpha.kubernetes.io/hostname: ingress.{{ .Values.captain_domain }}
+            type: "LoadBalancer"
+            externalTrafficPolicy: "Local"
           metrics:
             enabled: true
             serviceMonitor:

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -80,6 +80,7 @@ spec:
             default-ssl-certificate: glueops-core-cert-manager/{{ .Values.certManager.name_of_default_certificate }}
           service:
             annotations:
+              service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
               external-dns.alpha.kubernetes.io/hostname: ingress.{{ .Values.captain_domain }}
             type: "LoadBalancer"
             externalTrafficPolicy: "Local"


### PR DESCRIPTION
feat: using NLB in AWS. Note: the `service.beta.kubernetes.io/aws-load-balancer-type: "nlb"` should get ignored by other clouds as it's AWS specific. 
feat: admissionWebhooks is disabled. This is causing problems when using an overlay network. see: https://github.com/kubernetes/ingress-nginx/issues/10189

Did a quick test on GKE and the extra annotation isn't causing issues.