### PR TITLE
feat: update cert-manager from v1.12.2 -> v1.12.3

### DIFF
--- a/templates/application-cert-manager-crd.yaml
+++ b/templates/application-cert-manager-crd.yaml
@@ -13,7 +13,7 @@ spec:
   project: glueops-core
   source:
     repoURL: 'https://github.com/GlueOps/cert-manager-crds'
-    path: v1.12.2/
+    path: v1.12.3/
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-cert-manager
-    targetRevision: 0.8.1
+    targetRevision: 0.8.2
     helm:
       skipCrds: true
       parameters:


### PR DESCRIPTION
This needs to be merged/tagged/built/published first: https://github.com/GlueOps/platform-helm-chart-cert-manager/pull/14