### PR TITLE
Chore/updates

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.32.0
+version: 0.32.1

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://charts.bitnami.com/bitnami'
     chart: external-dns
-    targetRevision: 6.24.1
+    targetRevision: 6.24.2
     helm:
       parameters:
         - name: aws.credentials.secretKey

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -49,7 +49,7 @@ spec:
             image:
               registry: ghcr.io
               repository: glueops/alertmanager
-              tag: v0.26.0-glueops
+              tag: v0.26.1-glueops
             logLevel: debug
             replicas: 2
             # This externalURL is a hack. Alertmanager will reference back to itself per the code here: https://github.com/prometheus/alertmanager/blob/v0.25.0/template/default.tmpl#L2

--- a/templates/application-loki.yaml
+++ b/templates/application-loki.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://grafana.github.io/helm-charts'
     chart: loki
-    targetRevision: 5.15.0
+    targetRevision: 5.18.0
     helm:
       parameters:
         - name: loki.auth_enabled


### PR DESCRIPTION
 external dns updates: https://github.com/kubernetes-sigs/external-dns/releases/

 loki updates: 
 - increases default min and max replicas for autoscaling https://artifacthub.io/packages/helm/grafana/loki/5.18.0?modal=values&compare-to=5.15.0
 - update loki v2.8.4 -> v2.9.0 https://github.com/grafana/loki/releases/tag/v2.9.0