### PR TITLE
style(qr-code-generator): name application

### DIFF
--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -28,6 +28,7 @@ spec:
     targetRevision: 0.4.0
     helm:
       values: |-
+        appName: 'qr-code-generator'
         replicaCount: '2'
         image: 
           registry: ghcr.io


### PR DESCRIPTION
small change that we can include in the release or hold - we hadn't given an appName to the qr-code-generator, so it was called "example-app"

![image](https://github.com/GlueOps/platform-helm-chart-platform/assets/11429676/fb145d9b-6421-4e8c-9904-40b5924fb0f7)
