### PR TITLE
Release/prep for release of v0.34.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc5
+version: 0.34.0-rc6

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc1
+version: 0.34.0-rc2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc4
+version: 0.34.0-rc5

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc11
+version: 0.34.0-rc12

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc2
+version: 0.34.0-rc3

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc13
+version: 0.34.0-rc14

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc7
+version: 0.34.0-rc8

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.33.0
+version: 0.34.0-rc1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc10
+version: 0.34.0-rc11

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc8
+version: 0.34.0-rc9

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc12
+version: 0.34.0-rc13

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc14
+version: 0.34.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc6
+version: 0.34.0-rc7

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0-rc9
+version: 0.34.0-rc10

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc3](https://img.shields.io/badge/Version-0.34.0--rc3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc4](https://img.shields.io/badge/Version-0.34.0--rc4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 
@@ -44,6 +44,10 @@ This chart deploys the GlueOps Platform
 | glueops_node_and_tolerations.tolerations[0].key | string | `"glueops.dev/role"` |  |
 | glueops_node_and_tolerations.tolerations[0].operator | string | `"Equal"` |  |
 | glueops_node_and_tolerations.tolerations[0].value | string | `"glueops-platform"` |  |
+| glueops_operators.waf.aws_accessKey | string | `"placeholder_glueops_operators_waf_aws_access_key"` |  |
+| glueops_operators.waf.aws_secretKey | string | `"placeholder_glueops_operators_waf_aws_secret_key"` |  |
+| glueops_operators.web_acl.aws_accessKey | string | `"placeholder_glueops_operators_web_acl_aws_access_key"` |  |
+| glueops_operators.web_acl.aws_secretKey | string | `"placeholder_glueops_operators_web_acl_aws_secret_key"` |  |
 | grafana.admin_password | string | `"placeholder_grafana_admin_password"` | Default admin password. CHANGE THIS!!!! |
 | grafana.github_other_org_names | string | `"placeholder_tenant_github_org_name"` |  |
 | host_network.cert_manager.webhook_secure_port | int | `45020` |  |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc2](https://img.shields.io/badge/Version-0.34.0--rc2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc3](https://img.shields.io/badge/Version-0.34.0--rc3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc9](https://img.shields.io/badge/Version-0.34.0--rc9-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc10](https://img.shields.io/badge/Version-0.34.0--rc10-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc13](https://img.shields.io/badge/Version-0.34.0--rc13-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc14](https://img.shields.io/badge/Version-0.34.0--rc14-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc6](https://img.shields.io/badge/Version-0.34.0--rc6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc7](https://img.shields.io/badge/Version-0.34.0--rc7-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc1](https://img.shields.io/badge/Version-0.34.0--rc1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc2](https://img.shields.io/badge/Version-0.34.0--rc2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc5](https://img.shields.io/badge/Version-0.34.0--rc5-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc6](https://img.shields.io/badge/Version-0.34.0--rc6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc7](https://img.shields.io/badge/Version-0.34.0--rc7-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc8](https://img.shields.io/badge/Version-0.34.0--rc8-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc11](https://img.shields.io/badge/Version-0.34.0--rc11-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc12](https://img.shields.io/badge/Version-0.34.0--rc12-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc8](https://img.shields.io/badge/Version-0.34.0--rc8-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc9](https://img.shields.io/badge/Version-0.34.0--rc9-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc12](https://img.shields.io/badge/Version-0.34.0--rc12-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc13](https://img.shields.io/badge/Version-0.34.0--rc13-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc10](https://img.shields.io/badge/Version-0.34.0--rc10-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc11](https://img.shields.io/badge/Version-0.34.0--rc11-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0-rc4](https://img.shields.io/badge/Version-0.34.0--rc4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc5](https://img.shields.io/badge/Version-0.34.0--rc5-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.34.0-rc1](https://img.shields.io/badge/Version-0.34.0--rc1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -47,7 +47,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.7.3
+              image: ghcr.io/glueops/backup-tools:v0.7.4
               command: ["/bin/bash", "-c"]
               args:
                 - backup-vault
@@ -85,7 +85,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.7.3
+              image: ghcr.io/glueops/backup-tools:v0.7.4
               command: ["/bin/bash", "-c"]
               args:
                 - backup-loki-logs-as-json

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -47,7 +47,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.7.2
+              image: ghcr.io/glueops/backup-tools:v0.7.3
               command: ["/bin/bash", "-c"]
               args:
                 - backup-vault
@@ -85,7 +85,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.7.2
+              image: ghcr.io/glueops/backup-tools:v0.7.3
               command: ["/bin/bash", "-c"]
               args:
                 - backup-loki-logs-as-json

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -24,7 +24,7 @@ spec:
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.3.0
+    targetRevision: 0.4.0
     helm:
       values: |+
         appName: "glueops-backup-and-exports"

--- a/templates/application-cert-manager-crd.yaml
+++ b/templates/application-cert-manager-crd.yaml
@@ -13,7 +13,7 @@ spec:
   project: glueops-core
   source:
     repoURL: 'https://github.com/GlueOps/cert-manager-crds'
-    path: v1.12.4/
+    path: v1.12.5/
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-cert-manager
-    targetRevision: 0.8.3
+    targetRevision: 0.8.4
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-cluster-info-page.yaml
+++ b/templates/application-cluster-info-page.yaml
@@ -24,7 +24,7 @@ spec:
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.3.0
+    targetRevision: 0.4.0
     helm:
       values: |+
         appName: "glueops-cluster-info-page"

--- a/templates/application-external-secrets-crd.yaml
+++ b/templates/application-external-secrets-crd.yaml
@@ -31,5 +31,5 @@ spec:
     - "/spec/conversion/webhook/clientConfig/service/namespace"
   source:
     repoURL: 'https://github.com/GlueOps/external-secrets-crds'
-    path: v0.9.4/
+    path: v0.9.5/
     targetRevision: HEAD

--- a/templates/application-external-secrets-crd.yaml
+++ b/templates/application-external-secrets-crd.yaml
@@ -31,5 +31,5 @@ spec:
     - "/spec/conversion/webhook/clientConfig/service/namespace"
   source:
     repoURL: 'https://github.com/GlueOps/external-secrets-crds'
-    path: v0.9.5/
+    path: v0.9.6/
     targetRevision: HEAD

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-external-secrets
-    targetRevision: 0.5.0
+    targetRevision: 0.5.1
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-external-secrets
-    targetRevision: 0.4.3
+    targetRevision: 0.5.0
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -29,7 +29,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-alerts
-    targetRevision: 0.4.0
+    targetRevision: 0.3.0
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -29,7 +29,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-alerts
-    targetRevision: 0.3.0
+    targetRevision: 0.4.0
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-glueops-operator-waf-web-acl.yaml
+++ b/templates/application-glueops-operator-waf-web-acl.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf-web-acl
-          tag: v0.1.0
+          tag: v0.2.0
           port: 8000
 
         service:
@@ -52,6 +52,8 @@ spec:
               value: "us-east-1"
             - name: CAPTAIN_DOMAIN
               value: "{{ .Values.captain_domain }}"
+            - name: LOG_LEVEL
+              value: "INFO"
               
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           replicas: 2

--- a/templates/application-glueops-operator-waf-web-acl.yaml
+++ b/templates/application-glueops-operator-waf-web-acl.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.3.0
+    targetRevision: 0.4.0
     helm:
       values: |
         appName: 'glueops-operator-waf-web-acl'

--- a/templates/application-glueops-operator-waf-web-acl.yaml
+++ b/templates/application-glueops-operator-waf-web-acl.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf-web-acl
-          tag: v0.2.0
+          tag: v0.2.1
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.3.0
+    targetRevision: 0.4.0
     helm:
       values: |
         appName: 'glueops-operator-waf'

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.2.0
+          tag: v0.3.0
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.1.0
+          tag: v0.2.0
           port: 8000
 
         service:
@@ -58,6 +58,8 @@ spec:
               value: "https://vault-active.glueops-core-vault.svc.cluster.local:8200"
             - name: K8S_ROLE
               value: "reader-role"
+            - name: LOG_LEVEL
+              value: "INFO"
               
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           replicas: 2

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/charts/crds/crds
-    targetRevision: kube-prometheus-stack-51.0.3
+    targetRevision: kube-prometheus-stack-51.2.0
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/charts/crds/crds
-    targetRevision: kube-prometheus-stack-51.2.0
+    targetRevision: kube-prometheus-stack-51.9.0
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/charts/crds/crds
-    targetRevision: kube-prometheus-stack-51.9.0
+    targetRevision: kube-prometheus-stack-51.9.2
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -49,7 +49,7 @@ spec:
             image:
               registry: ghcr.io
               repository: glueops/alertmanager
-              tag: v0.26.1-glueops
+              tag: v0.26.2-glueops
             logLevel: debug
             replicas: 2
             # This externalURL is a hack. Alertmanager will reference back to itself per the code here: https://github.com/prometheus/alertmanager/blob/v0.25.0/template/default.tmpl#L2

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
     chart: kube-prometheus-stack
-    targetRevision: 51.9.0
+    targetRevision: 51.9.2
     helm:
       skipCrds: true
       values: |-

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
     chart: kube-prometheus-stack
-    targetRevision: 51.2.0
+    targetRevision: 51.9.0
     helm:
       skipCrds: true
       values: |-
@@ -95,7 +95,7 @@ spec:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           adminPassword: "{{ .Values.grafana.admin_password }}"
           image:
-            tag: 10.1.2
+            tag: 10.1.5
           ingress:
             enabled: true
             ingressClassName: public-authenticated

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
     chart: kube-prometheus-stack
-    targetRevision: 51.0.3
+    targetRevision: 51.2.0
     helm:
       skipCrds: true
       values: |-

--- a/templates/application-loki-alert-group-controller.yaml
+++ b/templates/application-loki-alert-group-controller.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.3.0
+    targetRevision: 0.4.0
     helm:
       values: |
         appName: '{{ .Release.Name }}'

--- a/templates/application-loki.yaml
+++ b/templates/application-loki.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://grafana.github.io/helm-charts'
     chart: loki
-    targetRevision: 5.22.0
+    targetRevision: 5.31.0
     helm:
       parameters:
         - name: loki.auth_enabled

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: metacontroller-helm
-    targetRevision: v4.11.2
+    targetRevision: v4.11.3
     helm:
       parameters:
         - name: replicas

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: metacontroller-helm
-    targetRevision: v4.11.1
+    targetRevision: v4.11.2
     helm:
       parameters:
         - name: replicas

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: metacontroller-helm
-    targetRevision: v4.11.3
+    targetRevision: v4.11.5
     helm:
       parameters:
         - name: replicas

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: metacontroller-helm
-    targetRevision: v4.11.0
+    targetRevision: v4.11.1
     helm:
       parameters:
         - name: replicas

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://kubernetes.github.io/ingress-nginx'
     chart: ingress-nginx
-    targetRevision: v4.7.2
+    targetRevision: v4.8.3
     helm:
       values: |-
         controller:

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://kubernetes.github.io/ingress-nginx'
     chart: ingress-nginx
-    targetRevision: v4.8.3
+    targetRevision: v4.8.2
     helm:
       values: |-
         controller:

--- a/templates/application-pomerium.yaml
+++ b/templates/application-pomerium.yaml
@@ -26,4 +26,4 @@ spec:
   source:
     repoURL: https://github.com/GlueOps/platform-kustomize-pomerium.git
     path: .
-    targetRevision: v0.4.0
+    targetRevision: v0.4.1

--- a/templates/application-promtail.yaml
+++ b/templates/application-promtail.yaml
@@ -33,7 +33,7 @@ spec:
           value: http://loki-write.glueops-core-loki.svc.cluster.local:3100/loki/api/v1/push
       values: |-
         image:
-          tag: 2.9.1
+          tag: 2.9.2
         tolerations:
           {{- toYaml .Values.glueops_node_and_tolerations.tolerations | nindent 10 }}
         config:

--- a/templates/application-pull-request-bot.yaml
+++ b/templates/application-pull-request-bot.yaml
@@ -25,7 +25,7 @@ spec:
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.3.0
+    targetRevision: 0.4.0
     helm:
       values: |
         appName: 'pull-request-bot'

--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -25,7 +25,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/project-template'
     chart: app
-    targetRevision: 0.3.0
+    targetRevision: 0.4.0
     helm:
       values: |-
         replicaCount: '2'

--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -28,6 +28,7 @@ spec:
     targetRevision: 0.4.0
     helm:
       values: |-
+        appName: 'qr-code-generator'
         replicaCount: '2'
         image: 
           registry: ghcr.io

--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -32,7 +32,7 @@ spec:
         image: 
           registry: ghcr.io
           repository: glueops/qr-code-generator
-          tag: v0.2.1
+          tag: v0.2.2
           pullPolicy: IfNotPresent
           port: 8000
                 

--- a/templates/application-vault-init-controller.yaml
+++ b/templates/application-vault-init-controller.yaml
@@ -24,7 +24,7 @@ spec:
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.3.0
+    targetRevision: 0.4.0
     helm:
       values: |
         appName: 'vault-init-controller'

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -44,7 +44,7 @@ spec:
         server:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           image:
-            tag: 1.14.3
+            tag: 1.14.4
           dataStorage:
             size: {{ .Values.vault.data_storage }}Gi
           ingress:


### PR DESCRIPTION
I branched this off release/v0.34.0 so we don't mess with his existing QA workflow


Notes:

feat: adding operator for WAF
feat: adding operator for WAF WebACL
MAJOR: new variables required:
- glueops_operators.waf.aws_accessKey
- glueops_operators.waf.aws_secretKey
- glueops_operators.web_acl.aws_accessKey
- glueops_operators.web_acl.aws_secretKey

feat: adding support to deploy WAF via app helm chart (0.4.0)

feat: updating backup tools:
- vault 1.14.3 -> 1.14.4
- loki 2.9.1 -> 2.9.2
- cert-manager 1.12.4 -> 1.12.5

feat: external-secrets 0.9.4 -> 0.9.6
- added retries for vault secret store (max 5 every 10s)

feat: kube-prometheus-stack 51.0.3 -> 51.9.2
- alertmanager v0.26.1 -> v0.26.2
- grafana 10.1.2 -> 10.1.5

feat: loki 5.22.0 -> 5.31.0

- app version of loki 2.9.1 -> 2.9.2

feat: metacontroller 4.11.0 -> 4.11.5
feat: ingress nginx 4.7.2 -> 4.8.2
feat: pomerium v0.23.0 -> v0.23.1
feat: promtail 2.9.1 -> 2.9.2
feat: vault 1.14.3 -> 1.14.4
