### PR TITLE
Release/0.35.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc7
+version: 0.35.0-rc8

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc8
+version: 0.35.0-rc9

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc2
+version: 0.35.0-rc3

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc6
+version: 0.35.0-rc7

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc1
+version: 0.35.0-rc2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc9
+version: 0.35.0-rc10

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc11
+version: 0.35.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc4
+version: 0.35.0-rc5

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.34.0
+version: 0.35.0-rc1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc3
+version: 0.35.0-rc4

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc10
+version: 0.35.0-rc11

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.0-rc5
+version: 0.35.0-rc6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.0-rc2](https://img.shields.io/badge/Version-0.35.0--rc2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc3](https://img.shields.io/badge/Version-0.35.0--rc3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.0-rc5](https://img.shields.io/badge/Version-0.35.0--rc5-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc6](https://img.shields.io/badge/Version-0.35.0--rc6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.0-rc8](https://img.shields.io/badge/Version-0.35.0--rc8-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc9](https://img.shields.io/badge/Version-0.35.0--rc9-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.0-rc4](https://img.shields.io/badge/Version-0.35.0--rc4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc5](https://img.shields.io/badge/Version-0.35.0--rc5-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.0-rc6](https://img.shields.io/badge/Version-0.35.0--rc6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc7](https://img.shields.io/badge/Version-0.35.0--rc7-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.0-rc1](https://img.shields.io/badge/Version-0.35.0--rc1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc2](https://img.shields.io/badge/Version-0.35.0--rc2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.34.0](https://img.shields.io/badge/Version-0.34.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc1](https://img.shields.io/badge/Version-0.35.0--rc1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.0-rc10](https://img.shields.io/badge/Version-0.35.0--rc10-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc11](https://img.shields.io/badge/Version-0.35.0--rc11-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.0-rc7](https://img.shields.io/badge/Version-0.35.0--rc7-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc8](https://img.shields.io/badge/Version-0.35.0--rc8-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.0-rc9](https://img.shields.io/badge/Version-0.35.0--rc9-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc10](https://img.shields.io/badge/Version-0.35.0--rc10-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.0-rc3](https://img.shields.io/badge/Version-0.35.0--rc3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.35.0-rc4](https://img.shields.io/badge/Version-0.35.0--rc4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/templates/application-argocd-servicemonitors.yaml
+++ b/templates/application-argocd-servicemonitors.yaml
@@ -1,0 +1,129 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-servicemonitors
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    name: "in-cluster"
+    namespace: glueops-core
+  project: glueops-core
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=false
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      backoff:
+        duration: 60s
+        maxDuration: 3m0s
+        factor: 2
+      limit: 10
+  source:
+    repoURL: https://helm.gpkg.io/project-template
+    chart: app
+    targetRevision: 0.4.0
+    helm:
+      values: |
+        appName: '{{ .Release.Name }}'
+        
+        # https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+        # https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
+        # https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
+        # https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+        # https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+
+        customResources:
+          - |-
+            apiVersion: monitoring.coreos.com/v1
+            kind: ServiceMonitor
+            metadata:
+              name: argocd-application-controller
+            spec:
+              endpoints:
+                - port: http-metrics
+                  interval: 30s
+                  path: /metrics
+              namespaceSelector:
+                matchNames:
+                  - glueops-core
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-metrics
+                  app.kubernetes.io/instance: argocd
+                  app.kubernetes.io/component: application-controller
+          - |-
+            apiVersion: monitoring.coreos.com/v1
+            kind: ServiceMonitor
+            metadata:
+              name: argocd-applicationset-controller
+            spec:
+              endpoints:
+                - port: http-metrics
+                  interval: 30s
+                  path: /metrics
+              namespaceSelector:
+                matchNames:
+                  - glueops-core
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-metrics
+                  app.kubernetes.io/instance: argocd
+                  app.kubernetes.io/component: applicationset-controller
+          - |-
+            apiVersion: monitoring.coreos.com/v1
+            kind: ServiceMonitor
+            metadata:
+              name: argocd-notifications-controller
+            spec:
+              endpoints:
+                - port: http-metrics
+                  path: /metrics
+              namespaceSelector:
+                matchNames:
+                  - glueops-core
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-metrics
+                  app.kubernetes.io/instance: argocd
+                  app.kubernetes.io/component: notifications-controller
+          - |-
+            apiVersion: monitoring.coreos.com/v1
+            kind: ServiceMonitor
+            metadata:
+              name: argocd-repo-server
+            spec:
+              endpoints:
+                - port: http-metrics
+                  interval: 30s
+                  path: /metrics
+              namespaceSelector:
+                matchNames:
+                  - glueops-core
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-repo-server-metrics
+                  app.kubernetes.io/instance: argocd
+                  app.kubernetes.io/component: repo-server
+          - |-
+            apiVersion: monitoring.coreos.com/v1
+            kind: ServiceMonitor
+            metadata:
+              name: argocd-server
+            spec:
+              endpoints:
+                - port: http-metrics
+                  interval: 30s
+                  path: /metrics
+              namespaceSelector:
+                matchNames:
+                  - glueops-core
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-server-metrics
+                  app.kubernetes.io/instance: argocd
+                  app.kubernetes.io/component: server

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -47,7 +47,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.7.5
+              image: ghcr.io/glueops/backup-tools:v0.7.6
               command: ["/bin/bash", "-c"]
               args:
                 - backup-vault
@@ -85,7 +85,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.7.5
+              image: ghcr.io/glueops/backup-tools:v0.7.6
               command: ["/bin/bash", "-c"]
               args:
                 - backup-loki-logs-as-json

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -47,7 +47,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.7.4
+              image: ghcr.io/glueops/backup-tools:v0.7.5
               command: ["/bin/bash", "-c"]
               args:
                 - backup-vault
@@ -85,7 +85,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.7.4
+              image: ghcr.io/glueops/backup-tools:v0.7.5
               command: ["/bin/bash", "-c"]
               args:
                 - backup-loki-logs-as-json

--- a/templates/application-cert-manager-crd.yaml
+++ b/templates/application-cert-manager-crd.yaml
@@ -13,7 +13,7 @@ spec:
   project: glueops-core
   source:
     repoURL: 'https://github.com/GlueOps/cert-manager-crds'
-    path: v1.12.5/
+    path: v1.13.2/
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-cert-manager
-    targetRevision: 0.8.4
+    targetRevision: 0.9.0
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://charts.bitnami.com/bitnami'
     chart: external-dns
-    targetRevision: 6.26.1
+    targetRevision: 6.28.1
     helm:
       parameters:
         - name: aws.credentials.secretKey

--- a/templates/application-external-secrets-crd.yaml
+++ b/templates/application-external-secrets-crd.yaml
@@ -31,5 +31,5 @@ spec:
     - "/spec/conversion/webhook/clientConfig/service/namespace"
   source:
     repoURL: 'https://github.com/GlueOps/external-secrets-crds'
-    path: v0.9.7/
+    path: v0.9.8/
     targetRevision: HEAD

--- a/templates/application-external-secrets-crd.yaml
+++ b/templates/application-external-secrets-crd.yaml
@@ -31,5 +31,5 @@ spec:
     - "/spec/conversion/webhook/clientConfig/service/namespace"
   source:
     repoURL: 'https://github.com/GlueOps/external-secrets-crds'
-    path: v0.9.6/
+    path: v0.9.7/
     targetRevision: HEAD

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-external-secrets
-    targetRevision: 0.5.2
+    targetRevision: 0.5.3
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-external-secrets
-    targetRevision: 0.5.1
+    targetRevision: 0.5.2
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -34,7 +34,7 @@ spec:
 
         image:
           registry: ghcr.io
-          tag: v0.2.1
+          tag: v0.2.2
           repository: glueops/cluster-monitoring
           pullPolicy: IfNotPresent
         deployment:

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -6,8 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: "10"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"
@@ -27,11 +25,201 @@ spec:
         maxDuration: 3m0s
       limit: 5
   source:
-    repoURL: 'https://helm.gpkg.io/platform'
-    chart: glueops-alerts
-    targetRevision: 0.3.0
+    repoURL: https://helm.gpkg.io/project-template
+    chart: app
+    targetRevision: 0.4.0
     helm:
-      skipCrds: true
-      parameters:
-        - name: prometheus-alertmanagerconfig-opsgenie.opsgenie.apikey
-          value: {{ .Values.glueops_alerts.opsgenie_apikey }}
+      values: |
+        appName: 'glueops-core-alerts'
+
+        secret:
+          enabled: true
+          secrets:
+            glueops-alerts:
+              data:
+                opsgenie_apikey: {{ .Values.glueops_alerts.opsgenie_apikey }}
+
+        customResources:
+          - |-
+            apiVersion: monitoring.coreos.com/v1alpha1
+            kind: AlertmanagerConfig
+            metadata:
+              name: glueops-alerts
+              namespace: glueops-core-alerts
+            spec:
+              receivers:
+              - name: glueops-alerts
+                opsgenieConfigs:
+                - apiKey:
+                    key: opsgenie_apikey
+                    name: glueops-core-alerts-glueops-alerts
+                  apiURL: https://api.opsgenie.com/
+                  sendResolved: true
+                  updateAlerts: true
+              route:
+                groupBy:
+                - '...'
+                groupInterval: 5m
+                matchers:
+                - name: namespace
+                  value: glueops-core-alerts
+                receiver: glueops-alerts
+                repeatInterval: 5m
+          - |-
+            apiVersion: monitoring.coreos.com/v1
+            kind: PrometheusRule
+            metadata:
+              name: glueops-pod-in-bad-state
+            spec:
+              groups:
+              - name: glueops-pod-in-bad-state
+                rules:
+                - alert: glueops-pod-in-bad-state
+                  expr: |
+                    (kube_pod_status_phase{namespace=~"^(kube-system|glueops-core-.*|glueops-core)$", pod!~"^(captain-redis-ha-configmap-test|captain-redis-ha-service-test)$", phase=~"^(Failed|Unknown|ContainerCreating|CrashLoopBackOff|ImagePullBackOff|ErrImageNeverPull|Pending)$"} == 1)
+                    or
+                    (kube_pod_status_ready{namespace=~"^(kube-system|glueops-core-.*|glueops-core)$", pod!~"^(captain-redis-ha-configmap-test|captain-redis-ha-service-test|glueops-backup-and-exports-.*)$", condition="false"} == 1)
+                    or
+                    (kube_pod_status_restarts_total{namespace=~"^(kube-system|glueops-core-.*|glueops-core)$"} > 3)
+                  for: 1m
+                  annotations:
+                    description: A GlueOps pod is in a bad state.
+                  labels:
+                    alertname: glueops-core-alerts
+                    namespace: glueops-core-alerts
+          - |-
+            apiVersion: monitoring.coreos.com/v1
+            kind: PrometheusRule
+            metadata:
+              name: glueops-node-rules
+            spec:
+              groups:
+              - name: glueops-node-rules
+                rules:
+                - alert: glueops-node-rules-NodeHighCpuUsage
+                  expr: (100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 95
+                  for: 1m
+                  annotations:
+                    description: worker node high cpu usage
+                  labels:
+                    alertname: glueops-core-alerts
+                    namespace: glueops-core-alerts
+                - alert: glueops-node-rules-NodeHighDiskUsage
+                  expr: (node_filesystem_avail_bytes / node_filesystem_size_bytes) * 100 < 10
+                  for: 1m
+                  annotations:
+                    description: worker node high disk usage
+                  labels:
+                    alertname: glueops-core-alerts
+                    namespace: glueops-core-alerts
+                - alert: glueops-node-rules-NodeHighPvcDiskUsage
+                  expr: (kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes) * 100 < 10
+                  for: 1m
+                  annotations:
+                    description: high pvc disk usage
+                  labels:
+                    alertname: glueops-core-alerts
+                    namespace: glueops-core-alerts
+                - alert: glueops-node-rules-NodeNotReady
+                  expr: kube_node_status_condition{condition="Ready",status="false"} == 1
+                  for: 8m
+                  annotations:
+                    description: Worker node not ready
+                  labels:
+                    alertname: glueops-core-alerts
+                    namespace: glueops-core-alerts
+                - alert: glueops-node-rules-NodeHighMemory
+                  expr: (1 - ((node_memory_MemFree_bytes + node_memory_Cached_bytes + node_memory_Buffers_bytes) / node_memory_MemTotal_bytes)) * 100 > 90
+                  for: 1m
+                  annotations:
+                    description: Worker node high memory usage
+                  labels:
+                    alertname: glueops-core-alerts
+                    namespace: glueops-core-alerts
+          - |-
+            apiVersion: monitoring.coreos.com/v1
+            kind: PrometheusRule
+            metadata:
+              name: glueops-pvc-near-capacity
+            spec:
+              groups:
+              - name: glueops-pvc-near-capacity
+                rules:
+                - alert: glueops-pvc-near-capacity
+                  expr: |
+                    (
+                      sum(kubelet_volume_stats_used_bytes{namespace=~"glueops-core.*"}) by (persistentvolumeclaim, namespace)
+                      / on (persistentvolumeclaim, namespace) group_left
+                      sum(kubelet_volume_stats_capacity_bytes{namespace=~"glueops-core.*"}) by (persistentvolumeclaim, namespace)
+                    ) > 0.9
+                  for: 1m
+                  annotations:
+                    description: A GlueOps PVC has exceeded 90% capacity.
+                  labels:
+                    alertname: glueops-core-alerts
+                    namespace: glueops-core-alerts
+          - |-
+            apiVersion: metacontroller.glueops.dev/v1alpha1
+            kind: LokiAlertRuleGroup
+            metadata:
+              name: glueops-services-high-5xx-rate-pomerium
+            spec:
+              name: glueops-services-high-5xx-rate-pomerium
+              rules:
+                - alert: glueops-services-high-5xx-rate-pomerium
+                  expr: |
+                    sum by (authority) (
+                      count_over_time({namespace="pomerium"} | json | response_code=~"5\\d{2}"[5m])
+                    )
+                    /
+                    sum by (authority) (
+                      count_over_time({namespace="pomerium"} | json | response_code=~"\\d{3}"[5m])
+                    ) > 0.01
+                  for: 1m
+                  annotations:
+                    description: GlueOps services are returning a high rate of 5xx responses via pomerium.
+                  labels:
+                    alertname: glueops-core-alerts
+                    namespace: glueops-core-alerts
+          - |-
+            apiVersion: metacontroller.glueops.dev/v1alpha1
+            kind: LokiAlertRuleGroup
+            metadata:
+              name: glueops-services-high-5xx-rate-nginx
+            spec:
+              name: glueops-services-high-5xx-rate-nginx
+              rules:
+                - alert: glueops-services-high-5xx-rate-nginx
+                  expr: |
+                    sum(
+                      count_over_time({namespace="glueops-core-public-ingress-nginx"} | json | (status=~"5\\d{2}" or upstream_status=~"5\\d{2}")[5m])
+                    )
+                    /
+                    sum(
+                      count_over_time({namespace="glueops-core-public-ingress-nginx"} | json | response_code=~"\\d{3}"[5m])
+                    ) > 0.01
+                  for: 1m
+                  annotations:
+                    description: GlueOps services are returning a high rate of 5xx responses via nginx.
+                  labels:
+                    alertname: glueops-core-alerts
+                    namespace: glueops-core-alerts
+          - |-
+            apiVersion: metacontroller.glueops.dev/v1alpha1
+            kind: LokiAlertRuleGroup
+            metadata:
+              name: glueops-service-external-secrets-secret-store-not-ready
+            spec:
+              name: glueops-service-external-secrets-secret-store-not-ready
+              rules:
+                - alert: glueops-service-external-secrets-secret-store-not-ready
+                  expr: |
+                    sum(
+                      count_over_time({app="external-secrets"} | json | (error =~ ".*SecretStore .* is not ready.*")[1m])
+                    ) > 0
+                  for: 1m
+                  annotations:
+                    description: GlueOps service external secrets pod must be restarted due to secret store not ready state.
+                  labels:
+                    alertname: glueops-core-alerts
+                    namespace: glueops-core-alerts

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -34,7 +34,7 @@ spec:
 
         image:
           registry: ghcr.io
-          tag: v0.2.0
+          tag: v0.2.1
           repository: glueops/cluster-monitoring
           pullPolicy: IfNotPresent
         deployment:

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -34,7 +34,7 @@ spec:
 
         image:
           registry: ghcr.io
-          tag: v0.2.0-alpha2
+          tag: v0.2.0
           repository: glueops/cluster-monitoring
           pullPolicy: IfNotPresent
         deployment:

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -32,6 +32,22 @@ spec:
       values: |
         appName: 'glueops-core-alerts'
 
+        image:
+          registry: ghcr.io
+          tag: v0.2.0-alpha2
+          repository: glueops/cluster-monitoring
+          pullPolicy: IfNotPresent
+        deployment:
+          replicas: 1
+          enabled: true
+          envVariables:
+            - name: OPSGENIE_API_KEY
+              value: {{ .Values.glueops_alerts.opsgenie_apikey }}
+            - name: OPSGENIE_HEARTBEAT_NAME
+              value: {{ .Values.captain_domain }}
+            - name: OPSGENIE_PING_INTERVAL_MINUTES
+              value: 1
+
         secret:
           enabled: true
           secrets:

--- a/templates/application-glueops-grafana-dashboards.yaml
+++ b/templates/application-glueops-grafana-dashboards.yaml
@@ -26,4 +26,4 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-grafana-dashboards
-    targetRevision: 0.10.0
+    targetRevision: 0.10.1

--- a/templates/application-glueops-operator-waf-web-acl.yaml
+++ b/templates/application-glueops-operator-waf-web-acl.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf-web-acl
-          tag: v0.2.1
+          tag: v0.2.2
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf-web-acl.yaml
+++ b/templates/application-glueops-operator-waf-web-acl.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf-web-acl
-          tag: v0.2.2
+          tag: v0.2.3
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.3.1
+          tag: v0.3.2
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.3.0
+          tag: v0.3.1
           port: 8000
 
         service:

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/charts/crds/crds
-    targetRevision: kube-prometheus-stack-51.10.0
+    targetRevision: kube-prometheus-stack-52.0.1
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/charts/crds/crds
-    targetRevision: kube-prometheus-stack-51.9.2
+    targetRevision: kube-prometheus-stack-51.10.0
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/charts/crds/crds
-    targetRevision: kube-prometheus-stack-52.0.1
+    targetRevision: kube-prometheus-stack-52.1.0
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
     chart: kube-prometheus-stack
-    targetRevision: 51.10.0
+    targetRevision: 52.0.1
     helm:
       skipCrds: true
       values: |-

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
     chart: kube-prometheus-stack
-    targetRevision: 52.0.1
+    targetRevision: 52.1.0
     helm:
       skipCrds: true
       values: |-

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -95,7 +95,7 @@ spec:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           adminPassword: "{{ .Values.grafana.admin_password }}"
           image:
-            tag: 10.2.0
+            tag: 10.1.5
           ingress:
             enabled: true
             ingressClassName: public-authenticated

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
     chart: kube-prometheus-stack
-    targetRevision: 51.9.2
+    targetRevision: 51.10.0
     helm:
       skipCrds: true
       values: |-
@@ -95,7 +95,7 @@ spec:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           adminPassword: "{{ .Values.grafana.admin_password }}"
           image:
-            tag: 10.1.5
+            tag: 10.2.0
           ingress:
             enabled: true
             ingressClassName: public-authenticated

--- a/templates/application-loki-alert-group-controller.yaml
+++ b/templates/application-loki-alert-group-controller.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-loki-rule-group
-          tag: v0.2.5
+          tag: v0.2.6
           pullPolicy: IfNotPresent
           port: 80
 

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://kubernetes.github.io/ingress-nginx'
     chart: ingress-nginx
-    targetRevision: v4.8.2
+    targetRevision: v4.8.3
     helm:
       values: |-
         controller:

--- a/templates/application-pull-request-bot.yaml
+++ b/templates/application-pull-request-bot.yaml
@@ -32,7 +32,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/pull-request-bot
-          tag: v0.11.2
+          tag: v0.12.0
           pullPolicy: IfNotPresent
         serviceAccount:
           create: true

--- a/templates/application-pull-request-bot.yaml
+++ b/templates/application-pull-request-bot.yaml
@@ -32,7 +32,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/pull-request-bot
-          tag: v0.11.1
+          tag: v0.11.2
           pullPolicy: IfNotPresent
         serviceAccount:
           create: true

--- a/templates/application-pull-request-bot.yaml
+++ b/templates/application-pull-request-bot.yaml
@@ -32,7 +32,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/pull-request-bot
-          tag: v0.11.0
+          tag: v0.11.1
           pullPolicy: IfNotPresent
         serviceAccount:
           create: true

--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -33,7 +33,7 @@ spec:
         image: 
           registry: ghcr.io
           repository: glueops/qr-code-generator
-          tag: v0.2.2
+          tag: v0.2.3
           pullPolicy: IfNotPresent
           port: 8000
                 

--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -33,7 +33,7 @@ spec:
         image: 
           registry: ghcr.io
           repository: glueops/qr-code-generator
-          tag: v0.2.4
+          tag: v0.2.5
           pullPolicy: IfNotPresent
           port: 8000
                 

--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -33,7 +33,7 @@ spec:
         image: 
           registry: ghcr.io
           repository: glueops/qr-code-generator
-          tag: v0.2.3
+          tag: v0.2.4
           pullPolicy: IfNotPresent
           port: 8000
                 

--- a/templates/application-vault-init-controller.yaml
+++ b/templates/application-vault-init-controller.yaml
@@ -31,7 +31,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/vault-init-controller
-          tag: v0.1.3
+          tag: v0.1.4
         serviceAccount:
           create: true
           name: vault-init-controller

--- a/templates/application-vault-init-controller.yaml
+++ b/templates/application-vault-init-controller.yaml
@@ -31,7 +31,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/vault-init-controller
-          tag: v0.1.2
+          tag: v0.1.3
         serviceAccount:
           create: true
           name: vault-init-controller

--- a/templates/application-vault-init-controller.yaml
+++ b/templates/application-vault-init-controller.yaml
@@ -31,7 +31,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/vault-init-controller
-          tag: v0.1.1
+          tag: v0.1.2
         serviceAccount:
           create: true
           name: vault-init-controller

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -44,7 +44,7 @@ spec:
         server:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           image:
-            tag: 1.14.4
+            tag: 1.14.5
           dataStorage:
             size: {{ .Values.vault.data_storage }}Gi
           ingress:

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -44,7 +44,7 @@ spec:
         server:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           image:
-            tag: 1.14.5
+            tag: 1.14.6
           dataStorage:
             size: {{ .Values.vault.data_storage }}Gi
           ingress:


### PR DESCRIPTION
feat: vault 1.14.4 -> 1.14.6
feat:  vault-init-controller v0.1.1 -> v0.1.4
feat: qr-code-generator v0.2.2 -> v0.2.5
feat: pull-request-bot v0.11.0 -> v0.12.0
feat: ingress-nginx v4.8.2 -> v4.8.3
feat: metacontroller-loki-rule-group v0.2.6 -> v0.2.5
feat: kube-prometheus-stack 51.9.2 -> 52.1.0
feat: operator-waf v0.3.0 -> v0.3.2
feat: operator-waf-web-acl v0.2.1 -> v0.2.3
feat: grafana dashboards v0.10.0 -> v0.10.1
feat: glueops-core alerts migration to centralized helm chart for easier management/deployment
Replaces:
- https://github.com/GlueOps/platform-helm-chart-alerts
- https://github.com/GlueOps/platform-helm-chart-prometheus-alerts/tree/main/templates

Because we can use the central helm chart we no longer need these repos either:
 - https://github.com/GlueOps/service-helm-chart-loki-alert-rule
 - https://github.com/GlueOps/service-helm-chart-prometheus-prometheusrule

feat: adding opsgenie heartbeats to glueops-alerts
feat: glueops-external-secrets v0.5.1 (v0.9.6) -> v0.5.3 (v0.9.8)
feat: external dns (bitnami) v6.26.1 (v0.13.6) -> 6.28.1 (v0.13.6)
feat: glueops cert-manager 0.8.4 (v1.12.5) -> 0.9.0 (v1.13.2)
feat: backup tools v0.7.4 -> v0.7.6
feat: adding argocd monitoring for:
- argocd repo server
- argocd server
- argocd notifications controller
- argocd applicationset controller
- argocd application controller