### PR TITLE
feat: update ingress nginx v4.8.3 -> v4.8.4 and reject SSL requests when the hostname doesn't match

### DIFF
--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://kubernetes.github.io/ingress-nginx'
     chart: ingress-nginx
-    targetRevision: v4.8.3
+    targetRevision: v4.8.4
     helm:
       values: |-
         controller:
@@ -35,6 +35,7 @@ spec:
           replicaCount: {{ .Values.nginx.controller_replica_count }}
           maxUnavailable: 1
           config:
+            ssl-reject-handshake: true
             # https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/log-format.md
             # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
             log-format-upstream: '{


### PR DESCRIPTION
[…hen the hostname doesn't match](feat: update ingress nginx v4.8.3 -> v4.8.4 and reject SSL requests when the hostname doesn't match)