### PR TITLE
Release/v0.37.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc15
+version: 0.37.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc6
+version: 0.37.0-rc7

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc7
+version: 0.37.0-rc8

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc14
+version: 0.37.0-rc15

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc8
+version: 0.37.0-rc9

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.35.1
+version: 0.37.0-alpha1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc9
+version: 0.37.0-rc10

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc11
+version: 0.37.0-rc12

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc2
+version: 0.37.0-rc3

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-alpha1
+version: 0.37.0-rc2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc12
+version: 0.37.0-rc13

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc10
+version: 0.37.0-rc11

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc13
+version: 0.37.0-rc14

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc4
+version: 0.37.0-rc5

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc3
+version: 0.37.0-rc4

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.37.0-rc5
+version: 0.37.0-rc6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc7](https://img.shields.io/badge/Version-0.37.0--rc7-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc8](https://img.shields.io/badge/Version-0.37.0--rc8-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc14](https://img.shields.io/badge/Version-0.37.0--rc14-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc15](https://img.shields.io/badge/Version-0.37.0--rc15-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc8](https://img.shields.io/badge/Version-0.37.0--rc8-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc9](https://img.shields.io/badge/Version-0.37.0--rc9-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-alpha1](https://img.shields.io/badge/Version-0.37.0--alpha1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc2](https://img.shields.io/badge/Version-0.37.0--rc2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 
@@ -74,7 +74,7 @@ This chart deploys the GlueOps Platform
 | vault_init_controller.aws_accessKey | string | `"placeholder_vault_init_controller_aws_access_key"` | S3 Credentials to access the vault_access.json |
 | vault_init_controller.aws_region | string | `"placeholder_aws_region"` | S3 region to access the vault_access.json |
 | vault_init_controller.aws_secretKey | string | `"placeholder_vault_init_controller_aws_access_secret"` | S3 Credentials to access the vault_access.json |
-| vault_init_controller.enable_restore | bool | `false` | Enable/Disable restore of an existing backup upon a fresh deployment of vault during cluster bootstrap |
+| vault_init_controller.enable_restore | bool | `true` | Enable/Disable restore of an existing backup upon a fresh deployment of vault during cluster bootstrap |
 | vault_init_controller.pause_reconcile | bool | `false` | Enable/Disable reconcile |
 | vault_init_controller.reconcile_period | int | `30` | How often the controller should run |
 | vault_init_controller.s3_bucket_name | string | `"glueops-tenant-placeholder_tenant_key-primary"` | S3 bucket that will store the vault unseal key(s) and root token |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc5](https://img.shields.io/badge/Version-0.37.0--rc5-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc6](https://img.shields.io/badge/Version-0.37.0--rc6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc2](https://img.shields.io/badge/Version-0.37.0--rc2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-venkata-1](https://img.shields.io/badge/Version-0.37.0--venkata--1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 
@@ -60,6 +60,7 @@ This chart deploys the GlueOps Platform
 | host_network.keda.service.portHttpsTarget | int | `45053` |  |
 | host_network.keda.webhooks.healthProbePort | int | `45051` |  |
 | host_network.keda.webhooks.port | int | `45050` |  |
+| host_network.kube_pometheus_stack.admissionWebhooks.deployment.tls.internal_port | int | `45041` |  |
 | host_network.kube_pometheus_stack.prometheusOperator.tls.internal_port | int | `45040` |  |
 | host_network.nginx_public.controller.host_port.ports.http | int | `45030` |  |
 | host_network.nginx_public.controller.host_port.ports.https | int | `45031` |  |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc12](https://img.shields.io/badge/Version-0.37.0--rc12-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc13](https://img.shields.io/badge/Version-0.37.0--rc13-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc13](https://img.shields.io/badge/Version-0.37.0--rc13-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc14](https://img.shields.io/badge/Version-0.37.0--rc14-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This chart deploys the GlueOps Platform
 | vault_init_controller.aws_accessKey | string | `"placeholder_vault_init_controller_aws_access_key"` | S3 Credentials to access the vault_access.json |
 | vault_init_controller.aws_region | string | `"placeholder_aws_region"` | S3 region to access the vault_access.json |
 | vault_init_controller.aws_secretKey | string | `"placeholder_vault_init_controller_aws_access_secret"` | S3 Credentials to access the vault_access.json |
+| vault_init_controller.enable_restore | bool | `false` | Enable/Disable restore of an existing backup upon a fresh deployment of vault during cluster bootstrap |
 | vault_init_controller.pause_reconcile | bool | `false` | Enable/Disable reconcile |
 | vault_init_controller.reconcile_period | int | `30` | How often the controller should run |
 | vault_init_controller.s3_bucket_name | string | `"glueops-tenant-placeholder_tenant_key-primary"` | S3 bucket that will store the vault unseal key(s) and root token |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc4](https://img.shields.io/badge/Version-0.37.0--rc4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc5](https://img.shields.io/badge/Version-0.37.0--rc5-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc11](https://img.shields.io/badge/Version-0.37.0--rc11-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc12](https://img.shields.io/badge/Version-0.37.0--rc12-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc6](https://img.shields.io/badge/Version-0.37.0--rc6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc7](https://img.shields.io/badge/Version-0.37.0--rc7-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-venkata-1](https://img.shields.io/badge/Version-0.37.0--venkata--1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc3](https://img.shields.io/badge/Version-0.37.0--rc3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 
@@ -60,7 +60,7 @@ This chart deploys the GlueOps Platform
 | host_network.keda.service.portHttpsTarget | int | `45053` |  |
 | host_network.keda.webhooks.healthProbePort | int | `45051` |  |
 | host_network.keda.webhooks.port | int | `45050` |  |
-| host_network.kube_pometheus_stack.admissionWebhooks.deployment.tls.internal_port | int | `45041` |  |
+| host_network.kube_pometheus_stack.prometheusOperator.admissionWebhooks.deployment.tls.internal_port | int | `45041` |  |
 | host_network.kube_pometheus_stack.prometheusOperator.tls.internal_port | int | `45040` |  |
 | host_network.nginx_public.controller.host_port.ports.http | int | `45030` |  |
 | host_network.nginx_public.controller.host_port.ports.https | int | `45031` |  |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc3](https://img.shields.io/badge/Version-0.37.0--rc3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc4](https://img.shields.io/badge/Version-0.37.0--rc4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.35.1](https://img.shields.io/badge/Version-0.35.1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-alpha1](https://img.shields.io/badge/Version-0.37.0--alpha1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc9](https://img.shields.io/badge/Version-0.37.0--rc9-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc10](https://img.shields.io/badge/Version-0.37.0--rc10-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.37.0-rc10](https://img.shields.io/badge/Version-0.37.0--rc10-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.37.0-rc11](https://img.shields.io/badge/Version-0.37.0--rc11-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -34,6 +34,23 @@ spec:
           create: true
           name: vault-backup
 
+        image:
+          registry: ghcr.io
+          repository: glueops/vault-backup-validator
+          tag: v0.1.3
+  
+        deployment:
+          enabled: true
+          labels:
+            glueops.dev/app-name: vault-backup-validator
+          matchLabels:
+            glueops.dev/app-name: vault-backup-validator
+        service:
+          enabled: true
+          labels:
+            expose: "true"
+          type: ClusterIP
+          port: 8080
       
         cronJob:
           enabled: true
@@ -47,7 +64,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.7.6
+              image: ghcr.io/glueops/backup-tools:v0.8.0
               command: ["/bin/bash", "-c"]
               args:
                 - backup-vault
@@ -85,7 +102,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.7.6
+              image: ghcr.io/glueops/backup-tools:v0.8.0
               command: ["/bin/bash", "-c"]
               args:
                 - backup-loki-logs-as-json

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -64,7 +64,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.8.0
+              image: ghcr.io/glueops/backup-tools:v0.9.0
               command: ["/bin/bash", "-c"]
               args:
                 - backup-vault
@@ -102,7 +102,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.8.0
+              image: ghcr.io/glueops/backup-tools:v0.9.0
               command: ["/bin/bash", "-c"]
               args:
                 - backup-loki-logs-as-json

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -64,7 +64,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.9.0
+              image: ghcr.io/glueops/backup-tools:v0.9.1
               command: ["/bin/bash", "-c"]
               args:
                 - backup-vault
@@ -102,7 +102,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: ghcr.io/glueops/backup-tools:v0.9.0
+              image: ghcr.io/glueops/backup-tools:v0.9.1
               command: ["/bin/bash", "-c"]
               args:
                 - backup-loki-logs-as-json

--- a/templates/application-cert-manager-crd.yaml
+++ b/templates/application-cert-manager-crd.yaml
@@ -13,7 +13,7 @@ spec:
   project: glueops-core
   source:
     repoURL: 'https://github.com/GlueOps/cert-manager-crds'
-    path: v1.13.2/
+    path: v1.13.3/
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-cert-manager
-    targetRevision: 0.9.0
+    targetRevision: 0.9.1
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-cluster-info-page.yaml
+++ b/templates/application-cluster-info-page.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/cluster-information-help-page-html
-          tag: v0.1.0
+          tag: v0.1.1
           pullPolicy: IfNotPresent
           port: 80
         

--- a/templates/application-external-secrets-crd.yaml
+++ b/templates/application-external-secrets-crd.yaml
@@ -31,5 +31,5 @@ spec:
     - "/spec/conversion/webhook/clientConfig/service/namespace"
   source:
     repoURL: 'https://github.com/GlueOps/external-secrets-crds'
-    path: v0.9.9/
+    path: v0.9.10/
     targetRevision: HEAD

--- a/templates/application-external-secrets-crd.yaml
+++ b/templates/application-external-secrets-crd.yaml
@@ -31,5 +31,5 @@ spec:
     - "/spec/conversion/webhook/clientConfig/service/namespace"
   source:
     repoURL: 'https://github.com/GlueOps/external-secrets-crds'
-    path: v0.9.8/
+    path: v0.9.9/
     targetRevision: HEAD

--- a/templates/application-external-secrets-crd.yaml
+++ b/templates/application-external-secrets-crd.yaml
@@ -31,5 +31,5 @@ spec:
     - "/spec/conversion/webhook/clientConfig/service/namespace"
   source:
     repoURL: 'https://github.com/GlueOps/external-secrets-crds'
-    path: v0.9.10/
+    path: v0.9.11/
     targetRevision: HEAD

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-external-secrets
-    targetRevision: 0.5.5
+    targetRevision: 0.5.6
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-external-secrets
-    targetRevision: 0.5.4
+    targetRevision: 0.5.5
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: glueops-external-secrets
-    targetRevision: 0.5.3
+    targetRevision: 0.5.4
     helm:
       skipCrds: true
       parameters:

--- a/templates/application-glueops-operator-redis.yaml
+++ b/templates/application-glueops-operator-redis.yaml
@@ -1,0 +1,54 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: glueops-operator-shared-redis
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    name: "in-cluster"
+    namespace: glueops-core-operators
+  project: glueops-core
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      backoff:
+        duration: 5s
+        maxDuration: 3m0s
+        factor: 2
+      limit: 2
+  source:
+    repoURL: https://helm.gpkg.io/project-template
+    chart: app
+    targetRevision: 0.4.0
+    helm:
+      values: |
+        appName: 'glueops-operator-shared-redis'
+        image:
+          registry: docker.io
+          repository: redis
+          tag: 7.2.4-alpine3.19
+          port: 6379
+
+        service:
+          enabled: true
+          port: 6379
+
+        app:
+          port: 6379
+        deployment:
+              
+          {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
+          replicas: 1
+          enabled: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+

--- a/templates/application-glueops-operator-waf-web-acl.yaml
+++ b/templates/application-glueops-operator-waf-web-acl.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf-web-acl
-          tag: v0.2.5
+          tag: v0.2.6
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf-web-acl.yaml
+++ b/templates/application-glueops-operator-waf-web-acl.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf-web-acl
-          tag: v0.2.3
+          tag: v0.2.5
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf-web-acl.yaml
+++ b/templates/application-glueops-operator-waf-web-acl.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf-web-acl
-          tag: v0.2.6
+          tag: v0.2.7
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf-web-acl.yaml
+++ b/templates/application-glueops-operator-waf-web-acl.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf-web-acl
-          tag: v0.2.7
+          tag: v0.3.0
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.3.6
+          tag: v0.4.0
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.3.2
+          tag: v0.3.4
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.3.5
+          tag: v0.3.6
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.3.4
+          tag: v0.3.5
           port: 8000
 
         service:

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.4.0
+          tag: v0.5.0
           port: 8000
 
         service:
@@ -60,9 +60,15 @@ spec:
               value: "reader-role"
             - name: LOG_LEVEL
               value: "INFO"
+            - name: REDIS_CONNECTION_STRING
+              value: "redis://glueops-operator-shared-redis.glueops-core-operators.svc.cluster.local:6379"
+            - name: CACHE_TTL
+              value: "180"
+            - name: MAX_TTL_ORPHANED_CERTS
+              value: "172800"
               
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
-          replicas: 2
+          replicas: 4
           enabled: true
           resources:
             requests:
@@ -128,16 +134,16 @@ spec:
                   resource: configmaps
                   updateStrategy:
                     method: InPlace
-              resyncPeriodSeconds: 30
+              resyncPeriodSeconds: 120
               hooks:
                 sync:
                   webhook:
                     url: http://glueops-operator-waf.glueops-core-operators.svc.cluster.local/sync
-                    timeout: "60s"
+                    timeout: "180s"
                 finalize:
                   webhook:
                     url: http://glueops-operator-waf.glueops-core-operators.svc.cluster.local/finalize
-                    timeout: "60s"
+                    timeout: "180s"
         
 
 

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/charts/crds/crds
-    targetRevision: kube-prometheus-stack-55.1.0
+    targetRevision: kube-prometheus-stack-55.5.0
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/charts/crds/crds
-    targetRevision: kube-prometheus-stack-52.1.0
+    targetRevision: kube-prometheus-stack-55.1.0
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/charts/crds/crds
-    targetRevision: kube-prometheus-stack-55.5.0
+    targetRevision: kube-prometheus-stack-55.7.0
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
     chart: kube-prometheus-stack
-    targetRevision: 52.1.0
+    targetRevision: 55.1.0
     helm:
       skipCrds: true
       values: |-
@@ -65,6 +65,10 @@ spec:
           tls:
             internalPort: {{ .Values.host_network.kube_pometheus_stack.prometheusOperator.tls.internal_port }}
           admissionWebhooks:
+            deployment:
+              tls:
+                internalPort: {{ .Values.host_network.kube_pometheus_stack.prometheusOperator.admissionWebhooks.deployment.tls.internal_port }}
+              hostNetwork: {{ .Values.host_network.enabled }}
             patch:
               {{- toYaml .Values.glueops_node_and_tolerations | nindent 14 }}
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
@@ -95,7 +99,7 @@ spec:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           adminPassword: "{{ .Values.grafana.admin_password }}"
           image:
-            tag: 10.1.5
+            tag: 10.2.2
           ingress:
             enabled: true
             ingressClassName: public-authenticated

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -99,7 +99,7 @@ spec:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           adminPassword: "{{ .Values.grafana.admin_password }}"
           image:
-            tag: 10.2.3
+            tag: 10.2.2
           ingress:
             enabled: true
             ingressClassName: public-authenticated

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
     chart: kube-prometheus-stack
-    targetRevision: 55.1.0
+    targetRevision: 55.5.0
     helm:
       skipCrds: true
       values: |-

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
     chart: kube-prometheus-stack
-    targetRevision: 55.5.0
+    targetRevision: 55.7.0
     helm:
       skipCrds: true
       values: |-
@@ -99,7 +99,7 @@ spec:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           adminPassword: "{{ .Values.grafana.admin_password }}"
           image:
-            tag: 10.2.2
+            tag: 10.2.3
           ingress:
             enabled: true
             ingressClassName: public-authenticated

--- a/templates/application-loki-alert-group-controller.yaml
+++ b/templates/application-loki-alert-group-controller.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-loki-rule-group
-          tag: v0.2.6
+          tag: v0.2.7
           pullPolicy: IfNotPresent
           port: 80
 

--- a/templates/application-loki.yaml
+++ b/templates/application-loki.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://grafana.github.io/helm-charts'
     chart: loki
-    targetRevision: 5.40.1
+    targetRevision: 5.41.4
     helm:
       parameters:
         - name: loki.auth_enabled

--- a/templates/application-loki.yaml
+++ b/templates/application-loki.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://grafana.github.io/helm-charts'
     chart: loki
-    targetRevision: 5.31.0
+    targetRevision: 5.40.1
     helm:
       parameters:
         - name: loki.auth_enabled

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/platform'
     chart: metacontroller-helm
-    targetRevision: v4.11.5
+    targetRevision: v4.11.7
     helm:
       parameters:
         - name: replicas

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -34,3 +34,12 @@ spec:
           value: '1'
       values: |-
         {{- toYaml .Values.glueops_node_and_tolerations | nindent 8 }}
+
+        commandArgs:
+          - --zap-log-level=4
+          - --discovery-interval=20s
+          - --cache-flush-interval=30m
+          - --health-probe-bind-address=:8081
+          - --client-go-qps=600
+          - --client-go-burst=600
+          - --workers=100

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -31,6 +31,6 @@ spec:
     helm:
       parameters:
         - name: replicas
-          value: '2'
+          value: '1'
       values: |-
         {{- toYaml .Values.glueops_node_and_tolerations | nindent 8 }}

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://kubernetes.github.io/ingress-nginx'
     chart: ingress-nginx
-    targetRevision: v4.8.4
+    targetRevision: v4.8.3
     helm:
       values: |-
         controller:

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://kubernetes.github.io/ingress-nginx'
     chart: ingress-nginx
-    targetRevision: v4.8.3
+    targetRevision: v4.8.4
     helm:
       values: |-
         controller:
@@ -35,6 +35,7 @@ spec:
           replicaCount: {{ .Values.nginx.controller_replica_count }}
           maxUnavailable: 1
           config:
+            ssl-reject-handshake: true
             # https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/log-format.md
             # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
             log-format-upstream: '{

--- a/templates/application-promtail.yaml
+++ b/templates/application-promtail.yaml
@@ -33,7 +33,7 @@ spec:
           value: http://loki-write.glueops-core-loki.svc.cluster.local:3100/loki/api/v1/push
       values: |-
         image:
-          tag: 2.9.2
+          tag: 2.9.3
         tolerations:
           {{- toYaml .Values.glueops_node_and_tolerations.tolerations | nindent 10 }}
         config:

--- a/templates/application-pull-request-bot.yaml
+++ b/templates/application-pull-request-bot.yaml
@@ -32,7 +32,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/pull-request-bot
-          tag: v0.12.0
+          tag: v0.12.1
           pullPolicy: IfNotPresent
         serviceAccount:
           create: true

--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -33,7 +33,7 @@ spec:
         image: 
           registry: ghcr.io
           repository: glueops/qr-code-generator
-          tag: v0.2.5
+          tag: v0.2.7
           pullPolicy: IfNotPresent
           port: 8000
                 

--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -33,7 +33,7 @@ spec:
         image: 
           registry: ghcr.io
           repository: glueops/qr-code-generator
-          tag: v0.2.7
+          tag: v0.2.8
           pullPolicy: IfNotPresent
           port: 8000
                 

--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -33,7 +33,7 @@ spec:
         image: 
           registry: ghcr.io
           repository: glueops/qr-code-generator
-          tag: v0.2.8
+          tag: v0.2.9
           pullPolicy: IfNotPresent
           port: 8000
                 

--- a/templates/application-vault-init-controller.yaml
+++ b/templates/application-vault-init-controller.yaml
@@ -31,7 +31,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/vault-init-controller
-          tag: v0.2.0
+          tag: v0.2.1
         serviceAccount:
           create: true
           name: vault-init-controller

--- a/templates/application-vault-init-controller.yaml
+++ b/templates/application-vault-init-controller.yaml
@@ -31,7 +31,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/vault-init-controller
-          tag: v0.1.4
+          tag: v0.2.0
         serviceAccount:
           create: true
           name: vault-init-controller
@@ -81,3 +81,6 @@ spec:
             value: "{{ .Values.vault_init_controller.aws_region }}"
           - name: PAUSE_RECONCILE
             value: "{{ .Values.vault_init_controller.pause_reconcile }}"
+          - name: ENABLE_RESTORE
+            value: "{{ .Values.vault_init_controller.enable_restore }}"
+          

--- a/templates/application-vault-init-controller.yaml
+++ b/templates/application-vault-init-controller.yaml
@@ -17,10 +17,10 @@ spec:
       selfHeal: true
     retry:
       backoff:
-        duration: 5s
-        maxDuration: 3m0s
+        duration: 10s
         factor: 2
-      limit: 2
+        maxDuration: 3m0s
+      limit: 5
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
@@ -31,7 +31,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/vault-init-controller
-          tag: v0.2.1
+          tag: v0.2.2
         serviceAccount:
           create: true
           name: vault-init-controller
@@ -83,4 +83,7 @@ spec:
             value: "{{ .Values.vault_init_controller.pause_reconcile }}"
           - name: ENABLE_RESTORE
             value: "{{ .Values.vault_init_controller.enable_restore }}"
-          
+          - name: CAPTAIN_DOMAIN
+            value: "{{ .Values.captain_domain }}"
+          - name: BACKUP_PREFIX
+            value: "hashicorp-vault-backups"

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -44,7 +44,7 @@ spec:
         server:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           image:
-            tag: 1.14.6
+            tag: 1.14.8
           dataStorage:
             size: {{ .Values.vault.data_storage }}Gi
           ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,10 @@ host_network:
     prometheusOperator:
       tls:
         internal_port: 45040
+      admissionWebhooks:
+        deployment:
+          tls:
+            internal_port: 45041
   keda:
     webhooks:
       port: 45050

--- a/values.yaml
+++ b/values.yaml
@@ -188,7 +188,7 @@ vault_init_controller:
   # -- Enable/Disable reconcile
   pause_reconcile: false
   # -- Enable/Disable restore of an existing backup upon a fresh deployment of vault during cluster bootstrap
-  enable_restore: false
+  enable_restore: true
 
 
 glueops_operators:

--- a/values.yaml
+++ b/values.yaml
@@ -187,6 +187,8 @@ vault_init_controller:
   reconcile_period: 30
   # -- Enable/Disable reconcile
   pause_reconcile: false
+  # -- Enable/Disable restore of an existing backup upon a fresh deployment of vault during cluster bootstrap
+  enable_restore: false
 
 
 glueops_operators:


### PR DESCRIPTION
## Features and Upgrades

### Backup Tools Update
- **Version:** Updated from v0.7.6 to v0.9.1
- **Upgrades:**
  - AWS CLI: v2.13.20 to v2.14.6
  - GH CLI: v2.35.0 to v2.40.0
  - Rclone: v1.63.1 to v1.65.0
  - Vault: v1.14.6 to v1.14.8
  - Loki: v2.9.2 to v2.9.3
- **Fixes:**
  - Loki export/upload logic to prevent duplicate logs.
- **New Features:**
  - Added backup checking as part of the Vault backup process.
  - Added `vault-backup-validator` to ArgoCD app of backups-and-exports.

### Cert-Manager Updates
- Update cert-manager from v1.13.2 to v1.13.3.
- Update GlueOps cert-manager from v0.9.0 to v0.9.1.

### Cluster Information Help Page
- **Version:** Updated from v0.1.0 to v0.1.1
- **Improvements:**
  - Fixed ArgoCD URL to redirect to the login page instead of re-using potentially expired auth tokens.

### GlueOps External-Secrets
- **Version:** Updated from v0.5.3 to v0.5.6
- **Upgrades:**
  - External Secrets from v0.9.8 to v0.9.11.

### Additional Features
- Added GlueOps shared Redis instance for use by various GlueOps operators.
- Update GlueOps WAF operator for web ACL from v0.2.3 to v0.3.0:
  - Enabled multi-threading of app.

### GlueOps WAF Operator
- **Upgrades:**
  - Version: v0.3.2 to v0.5.0
  - Replicas increased from 2 to 4.
  - Resync period from 30s to 120s.
  - Webhook duration from 60s to 180s.
- **Improvements:**
  - Enabled multi-threading of app.
  - Added Redis cache + pyrate-limiter to avoid AWS API rate limiting.

### Kube-Prometheus-Stack
- **Upgrades:**
  - Version: v52.1.0 to v55.7.0
  - Grafana: v10.1.5 to v10.2.2
- **New Features:**
  - Added new host enabled port in `.Values.host_network.kube_prometheus_stack.prometheusOperator.admissionWebhooks.deployment.tls.internal_port`.

### Metacontroller
- **Version:** Updated from v4.11.5 to 4.11.7
- **Improvements:**
  - Reduced replicas to 1 to avoid duplicate events.

### Ingress NGINX
- Updated to reject SSL handshake if the hostname doesn't match during SSL connection requests.

### Loki and Promtail Updates
- Updated Loki from v2.9.2 to v2.9.3 and helm chart from v5.31.0 to v5.41.4.
- Updated Promtail from v2.9.2 to v2.9.3.

### Pull Request Bot
- **Version:** Updated from v0.12.0 to v0.12.1
- **Upgrades:**
  - Python from 3.11.6 to 3.11.7.
  - GlueOps helpers library from v0.3.0 to v0.4.0.

### QR Code Generator
- **Version:** Updated from v0.2.5 to v0.2.9.

### Vault-Init-Controller
- **Version:** Updated from v0.1.4 to v0.2.2.
- **New Features:**
  - Added support to restore the latest existing backup (enabled by default).
- **Improvements:**
  - Fixed ArgoCD app retries to match the logic in other ArgoCD apps, reducing failures during the bootstrap of new clusters.

### Vault
- **Version:** Updated from v1.14.6 to v1.14.8.

