### PR TITLE
hotfix: http-to-https redirect by default for glueops-operator-waf

### DIFF
--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.5.1
+          tag: v0.5.2
           port: 8000
 
         service:


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated the GlueOps Operator WAF image tag to `v0.5.2` to include the latest hotfixes, specifically the http-to-https redirect feature by default.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-glueops-operator-waf.yaml</strong><dd><code>Update GlueOps Operator WAF Image Tag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
templates/application-glueops-operator-waf.yaml

- Updated the image tag from `v0.5.1` to `v0.5.2`.



</details>
    

  </td>
  <td><a href="https:/GlueOps/platform-helm-chart-platform/pull/177/files#diff-59f2d123d85fdcee1a6d3a2997e19b7c22fb699a41e0334acba55bcdf20185a2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

