### PR TITLE
feat: change vault stateful set to use rollingUpdate when the container images change instead of requiring ondelete

### DIFF
--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -45,6 +45,7 @@ spec:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           image:
             tag: 1.14.9
+          updateStrategyType: "RollingUpdate"
           dataStorage:
             size: {{ .Values.vault.data_storage }}Gi
           ingress:


### PR DESCRIPTION
## **User description**
feat: change vault stateful set to use rollingUpdate when the container images change instead of requiring ondelete
ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies


___

## **Type**
enhancement


___

## **Description**
- Changed the update strategy of the Vault StatefulSet to use `RollingUpdate` instead of requiring manual deletion for updates. This enhancement allows for seamless updates of container images without downtime.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-vault.yaml</strong><dd><code>Implement RollingUpdate Strategy for Vault StatefulSet</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
templates/application-vault.yaml

<li>Added <code>updateStrategyType: "RollingUpdate"</code> to the vault stateful set <br>configuration.<br>


</details>
    

  </td>
  <td><a href="https:/GlueOps/platform-helm-chart-platform/pull/178/files#diff-cb4686972e88e1c744b094bfe3d13b6e64bf2a5b0a9bd9a69a7f187f4f387642">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

