### PR TITLE
feat: bump operator waf from 0.5.2 -> 0.6.0 - only accept TLSv1.2 or …

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.38.1
+version: 0.39.0

--- a/templates/application-glueops-operator-waf.yaml
+++ b/templates/application-glueops-operator-waf.yaml
@@ -33,7 +33,7 @@ spec:
         image:
           registry: ghcr.io
           repository: glueops/metacontroller-operator-waf
-          tag: v0.5.2
+          tag: v0.6.0
           port: 8000
 
         service:


### PR DESCRIPTION
## **User description**
…newer from the client


___

## **Type**
enhancement


___

## **Description**
- Updated the WAF operator image tag to `v0.6.0` to ensure only TLSv1.2 or newer is accepted from the client.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-glueops-operator-waf.yaml</strong><dd><code>Update WAF Operator Image Tag to v0.6.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
templates/application-glueops-operator-waf.yaml

<li>Updated the image tag for <code>glueops/metacontroller-operator-waf</code> from <br><code>v0.5.2</code> to <code>v0.6.0</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/179/files#diff-59f2d123d85fdcee1a6d3a2997e19b7c22fb699a41e0334acba55bcdf20185a2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

