### PR TITLE
feat(metacontroller): switch from helm repo to OCI repository

### DIFF
--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -25,9 +25,9 @@ spec:
       - Replace=true
       - CreateNamespace=true
   source:
-    repoURL: 'https://helm.gpkg.io/platform'
+    repoURL: 'ghcr.io/metacontroller'
     chart: metacontroller-helm
-    targetRevision: v4.11.8
+    targetRevision: 4.11.8
     helm:
       parameters:
         - name: replicas


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Switched Metacontroller source from a Helm repository to an OCI repository format.
- Updated the `targetRevision` to align with the new source, removing the 'v' prefix for versioning.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-metacontroller.yaml</strong><dd><code>Switch Metacontroller Source from Helm Repository to OCI Repository</code></dd></summary>
<hr>
      
templates/application-metacontroller.yaml

<li>Changed <code>repoURL</code> from Helm repository URL to OCI repository format.<br> <li> Updated <code>targetRevision</code> to remove the 'v' prefix.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/229/files#diff-ad91a818a3e321ad5e3a873b4bf5d6a443366295bf315ef4b790bcc99c4f00a0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

