### PR TITLE
Revert "Chore(deps) metacontroller pinning"

### DIFF
--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -43,7 +43,3 @@ spec:
           - --client-go-qps=600
           - --client-go-burst=600
           - --workers=100
-
-        image:
-          repository: {{ .Values.container_images.app_metacontroller.metacontroller.image.registry }}:{{ .Values.container_images.app_metacontroller.metacontroller.image.repository }}
-          tag: {{ .Values.container_images.app_metacontroller.metacontroller.image.tag }}

--- a/values.yaml
+++ b/values.yaml
@@ -330,12 +330,7 @@ container_images:
         registry: docker.io # not actually used
         repository: hashicorp/vault
         tag: 1.14.10@sha256:14be0a8eb323181a56d10facab3b424809d9921e85d2f2678126ce232766a8e1
-  app_metacontroller:
-    metacontroller:
-      image:
-        registry: ghcr.io
-        repository: metacontroller/metacontroller
-        tag: 4.11.11
+
 
 
 


### PR DESCRIPTION
## **User description**
Reverts GlueOps/platform-helm-chart-platform#233


___

## **Type**
bug_fix


___

## **Description**
- Removed the image specification for the metacontroller from `application-metacontroller.yaml`.
- Removed the `app_metacontroller` image configuration from `values.yaml`. This reverts the changes made in a previous commit, ensuring that the metacontroller image is no longer pinned to a specific version.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-metacontroller.yaml</strong><dd><code>Remove Metacontroller Image Specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
templates/application-metacontroller.yaml

- Removed the image specification for the metacontroller.



</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/234/files#diff-ad91a818a3e321ad5e3a873b4bf5d6a443366295bf315ef4b790bcc99c4f00a0">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Remove Metacontroller Image Configuration from Values</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
values.yaml

- Removed the `app_metacontroller` image configuration.



</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/234/files#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7e">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

