### PR TITLE
fix: tag for metacontroller

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -335,7 +335,7 @@ container_images:
       image:
         registry: ghcr.io
         repository: metacontroller/metacontroller
-        tag: 4.11.11@sha256:0fa3ae495bae010616f55814e785f12ac7346fce801df1afd3ec162ec5159470 #this might need to be updated manually because of renovatebot errors
+        tag: v4.11.11@sha256:0fa3ae495bae010616f55814e785f12ac7346fce801df1afd3ec162ec5159470 #this might need to be updated manually because of renovatebot errors
 
 
 


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Corrected the tag for the metacontroller image in `values.yaml` to properly prefix with 'v', ensuring compatibility or correctness with image tagging conventions.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Correct Metacontroller Image Tag Prefix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
values.yaml

<li>Corrected the tag for the metacontroller image to include the 'v' <br>prefix.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/236/files#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

