### PR TITLE
chore: bump version to 0.42.0-rc1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.41.0-rc3
+version: 0.42.0-rc1


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Bumped chart version to `0.42.0-rc1` for the GlueOps Platform Helm chart.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Bump Chart Version for GlueOps Platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Chart.yaml

- Bumped chart version from `0.41.0-rc3` to `0.42.0-rc1`.



</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/237/files#diff-d954583aa4c24cff0039bc948abd7c694fc3dab2030231d11ed1b3cda9b4ddbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

