### PR TITLE
feat: update metacontroller installation to use github tags instead of using oci repository. This also lets renovatebot work correctly since it can't parse oci.

### DIFF
--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -25,9 +25,9 @@ spec:
       - Replace=true
       - CreateNamespace=true
   source:
-    repoURL: 'ghcr.io/metacontroller'
-    chart: metacontroller-helm
-    targetRevision: 4.11.11
+    repoURL: https://github.com/metacontroller/metacontroller.git
+    path: deploy/helm/metacontroller
+    targetRevision: v4.11.11
     helm:
       parameters:
         - name: replicas


### PR DESCRIPTION
feat: update metacontroller installation to use github tags instead of using oci repository. This also lets renovatebot work correctly since it can't parse oci.