### PR TITLE
fix(fluentbit): reduce frequency of upload from 1m to default (10m)

### DIFF
--- a/templates/application-glueops-fluentbit.yaml
+++ b/templates/application-glueops-fluentbit.yaml
@@ -202,5 +202,4 @@ spec:
                 Bucket: "{{ .Values.glueops_backups.s3_bucket_name }}"
                 Region: "{{ .Values.glueops_backups.fluentbit_exporter_to_s3.aws_region }}"
                 S3KeyFormat: "/{{ .Values.captain_domain }}/fluentbit_exported_logs/$TAG/%Y/%m/%d/%H/%M/%S/$UUID.ndjson"
-                UploadTimeout: "1m"
                 ContentType: "application/x-ndjson"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed the `UploadTimeout` setting from the S3 configuration in the `application-glueops-fluentbit.yaml` template to revert to the default upload frequency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-glueops-fluentbit.yaml</strong><dd><code>Remove `UploadTimeout` setting from S3 configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-glueops-fluentbit.yaml
- Removed `UploadTimeout` setting from the S3 configuration.



</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/297/files#diff-0718b27d68508cc34168550b467b620e2d3ecebd8877a8768fe47aa04a57493b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

