### PR TITLE
fix: revert external dns back to v6

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.45.0-rc2
+version: 0.45.0-rc3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.45.0-rc2](https://img.shields.io/badge/Version-0.45.0--rc2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.45.0-rc3](https://img.shields.io/badge/Version-0.45.0--rc3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://charts.bitnami.com/bitnami'
     chart: external-dns
-    targetRevision: 7.5.7
+    targetRevision: 6.38.0
     helm:
       parameters:
         - name: aws.credentials.secretKey


### PR DESCRIPTION
### **User description**
There appear to be bugs in v7 helm chart: https://github.com/bitnami/charts/issues/25967


___

### **PR Type**
Bug fix


___

### **Description**
- Reverted `external-dns` Helm chart version from `7.5.7` to `6.38.0` due to bugs in version 7.
- Referenced issue: https://github.com/bitnami/charts/issues/25967


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-external-dns.yaml</strong><dd><code>Revert external-dns Helm chart version due to bugs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-external-dns.yaml
<li>Reverted <code>external-dns</code> Helm chart version from <code>7.5.7</code> to <code>6.38.0</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/343/files#diff-77f505fbaa80b2ae0f9386fda952a8ed063fc00d35b729f2f24a66b1070900f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

