### PR TITLE
fix(kube-prometheus-stack): latest pomerium update requires a new ann…

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.46.0
+version: 0.46.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.46.0](https://img.shields.io/badge/Version-0.46.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.46.1](https://img.shields.io/badge/Version-0.46.1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -109,6 +109,7 @@ spec:
               ingress.pomerium.io/pass_identity_headers: 'true'
               ingress.pomerium.io/allow_websockets: 'true'
               ingress.pomerium.io/idle_timeout: 0s
+              ingress.pomerium.io/preserve_host_header: 'true'
             hosts: ['grafana.{{ .Values.captain_domain }}']
             path: "/"
           additionalDataSources:


### PR DESCRIPTION
### **User description**
…otation to avoid breaking grafana/kube-prometheus-stack

https://github.com/pomerium/documentation/commit/5383013263c056235cecb5bf317b485e82ee89d7#diff-1509cb8fdfa04e4276e29253daa5c79751999ad1fc3de00af7fc473331621475R32


___

### **PR Type**
Bug fix


___

### **Description**
- Added the `ingress.pomerium.io/preserve_host_header` annotation to the ingress configuration in `application-kube-prometheus-stack.yaml` to comply with the latest Pomerium update and avoid breaking Grafana/kube-prometheus-stack.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-kube-prometheus-stack.yaml</strong><dd><code>Add preserve_host_header annotation to ingress configuration</code></dd></summary>
<hr>

templates/application-kube-prometheus-stack.yaml

- Added `ingress.pomerium.io/preserve_host_header` annotation.



</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/382/files#diff-87a59bc30480a9bd9c023721224637a3e2c117ea1b0a2843f98188bc105f3ce3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

