### PR TITLE
feat: add prometheus remote write

### DIFF
--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -92,6 +92,20 @@ spec:
                     requests:
                       storage: {{ .Values.prometheus.volume_claim_storage_request}}Gi
             hostNetwork: {{ .Values.host_network.enabled }}
+            remoteWriteDashboards: true
+            additionalRemoteWrite: 
+            - url: http://ingest.onglueopshosted.com/metrics/v1/push
+              writeRelabelConfigs:
+              - sourceLabels: [__name__]
+                regex: '.*'
+                action: 'replace'
+                targetLabel: 'captain_domain'
+                replacement: {{ .Values.captain_domain }}
+              - sourceLabels: [__name__]
+                regex: '.*'
+                action: 'replace'
+                targetLabel: 'glueops_platform_version'
+                replacement: {{ .Chart.Version }}
         grafana:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           adminPassword: "{{ .Values.grafana.admin_password }}"

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -94,7 +94,7 @@ spec:
             hostNetwork: {{ .Values.host_network.enabled }}
             remoteWriteDashboards: true
             additionalRemoteWrite: 
-            - url: http://ingest.onglueopshosted.com/metrics/v1/push
+            - url: http://ingest.glueopshosted.com/metrics/v1/push
               writeRelabelConfigs:
               - sourceLabels: [__name__]
                 regex: '.*'


### PR DESCRIPTION
### **User description**
Adding prometheus remote write.


___

### **PR Type**
enhancement


___

### **Description**
- Added `remoteWriteDashboards` to enable remote write dashboards.
- Introduced `additionalRemoteWrite` with a specific URL for pushing metrics.
- Configured relabeling for `captain_domain` and `glueops_platform_version` to enhance metric labeling.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-kube-prometheus-stack.yaml</strong><dd><code>Add Prometheus Remote Write Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-kube-prometheus-stack.yaml

<li>Added <code>remoteWriteDashboards</code> configuration.<br> <li> Introduced <code>additionalRemoteWrite</code> settings with URL and relabel <br>configurations.<br> <li> Configured relabeling for <code>captain_domain</code> and <code>glueops_platform_version</code>.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/383/files#diff-87a59bc30480a9bd9c023721224637a3e2c117ea1b0a2843f98188bc105f3ce3">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

