### PR TITLE
fix: remove alert for argocd redis init job

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.47.0
+version: 0.47.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.47.0](https://img.shields.io/badge/Version-0.47.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.47.1](https://img.shields.io/badge/Version-0.47.1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -94,7 +94,7 @@ spec:
                   expr: |
                     (kube_pod_status_phase{namespace=~"^(kube-system|glueops-core-.*|glueops-core|pomerium|chisel-operator-system)$", pod!~"^(captain-redis-ha-configmap-test|captain-redis-ha-service-test)$", phase=~"^(Failed|Unknown|ContainerCreating|CrashLoopBackOff|ImagePullBackOff|ErrImageNeverPull|Pending)$"} == 1)
                     or
-                    (kube_pod_status_ready{namespace=~"^(kube-system|glueops-core-.*|glueops-core|pomerium|chisel-operator-system)$", pod!~"^(captain-redis-ha-configmap-test|captain-redis-ha-service-test|glueops-backup-and-exports-.*|.*-presync-.*|pomerium-gen-secrets-.*)$", condition="false"} == 1)
+                    (kube_pod_status_ready{namespace=~"^(kube-system|glueops-core-.*|glueops-core|pomerium|chisel-operator-system)$", pod!~"^(captain-redis-ha-configmap-test|captain-redis-ha-service-test|glueops-backup-and-exports-.*|.*-presync-.*|pomerium-gen-secrets-.*|argocd-redis-secret-.*)$", condition="false"} == 1)
                     or
                     (kube_pod_status_restarts_total{namespace=~"^(kube-system|glueops-core-.*|glueops-core|pomerium|chisel-operator-system)$"} > 3)
                     or


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Excluded `argocd-redis-secret-*` pods from the `glueops-pod-in-bad-state` alert to prevent unnecessary alerts for the ArgoCD Redis init job.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-glueops-alerts.yaml</strong><dd><code>Remove alert for ArgoCD Redis init job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-glueops-alerts.yaml

<li>Excluded <code>argocd-redis-secret-*</code> pods from the <code>glueops-pod-in-bad-state</code> <br>alert.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/406/files#diff-360ed6e9dd855672acb53925c0ab6cce214159e7d5d293114a89b60757ba887e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

