### PR TITLE
fix: remove hardcoded captain domain for new otel stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This chart deploys the GlueOps Platform
 | loki.aws_region | string | `"placeholder_aws_region"` | Should be the same `primary_region` you used in: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | loki.aws_secretKey | string | `"placeholder_loki_aws_secret_key"` | Part of `loki_s3_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | loki.bucket | string | `"glueops-tenant-placeholder_tenant_key-primary"` | Format: glueops-tenant-placeholder_tenant_key-placeholder_cluster_environment-loki-primary, Credentials found at `loki_credentials` of json output of terraform-module-cloud-multy-prerequisites |
-| loki.prefix | string | `"nonprod.gliese581d.onglueops.rocks/loki/logs"` |  |
+| loki.prefix | string | `"placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain/loki/logs"` |  |
 | nginx.controller_replica_count | int | `2` | number of replicas for ingress controller |
 | otel.config | string | `nil` |  |
 | otel.manager.autoInstrumentationImage.apacheHttpd.repository | string | `""` |  |
@@ -186,13 +186,13 @@ This chart deploys the GlueOps Platform
 | tempo.aws_region | string | `"placeholder_aws_region"` | Should be the same `primary_region` you used in: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | tempo.aws_secretKey | string | `"placeholder_tempo_aws_secret_key"` | Part of `loki_s3_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | tempo.bucket | string | `"glueops-tenant-placeholder_tenant_key-primary"` | Format: glueops-tenant-gliese581d-nonprod-loki-primary, Credentials found at `loki_credentials` of json output of terraform-module-cloud-multy-prerequisites |
-| tempo.prefix | string | `"nonprod.gliese581d.onglueops.rocks/tempo/traces"` |  |
+| tempo.prefix | string | `"placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain/tempo/traces"` |  |
 | tempo.remote_url[0] | string | `"http://localhost:9090/api/v1/write"` |  |
 | thanos.aws_accessKey | string | `"placeholder_thanos_aws_access_key"` | Part of `loki_s3_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | thanos.aws_region | string | `"placeholder_aws_region"` | Should be the same `primary_region` you used in: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | thanos.aws_secretKey | string | `"placeholder_thanos_aws_secret_key"` | Part of `loki_s3_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | thanos.bucket | string | `"glueops-tenant-placeholder_tenant_key-primary"` | Format: glueops-tenant-placeholder_tenant_key-placeholder_cluster_environment-loki-primary, Credentials found at `loki_credentials` of json output of terraform-module-cloud-multy-prerequisites |
-| thanos.prefix | string | `"nonprod.gliese581d.onglueops.rocks/thanos/metrics"` |  |
+| thanos.prefix | string | `"placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain/thanos/metrics"` |  |
 | tls_cert_restore.aws_accessKey | string | `"placeholder_tls_cert_restore_aws_access_key"` | Part of `loki_log_exporter` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | tls_cert_restore.aws_region | string | `"placeholder_aws_region"` | Should be the same `primary_region` you used in: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | tls_cert_restore.aws_secretKey | string | `"placeholder_tls_cert_restore_aws_secret_key"` | Part of `loki_log_exporter` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |

--- a/values.yaml
+++ b/values.yaml
@@ -127,7 +127,7 @@ loki:
   # -- Part of `loki_s3_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites
   aws_secretKey: placeholder_loki_aws_secret_key
 
-  prefix: "nonprod.gliese581d.onglueops.rocks/loki/logs"
+  prefix: "placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain/loki/logs"
 
 thanos:
   # -- Format: glueops-tenant-placeholder_tenant_key-placeholder_cluster_environment-loki-primary, Credentials found at `loki_credentials` of json output of terraform-module-cloud-multy-prerequisites
@@ -139,7 +139,7 @@ thanos:
   # -- Part of `loki_s3_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites
   aws_secretKey: placeholder_thanos_aws_secret_key  
 
-  prefix: "nonprod.gliese581d.onglueops.rocks/thanos/metrics"
+  prefix: "placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain/thanos/metrics"
 
 tempo:
   # -- Format: glueops-tenant-gliese581d-nonprod-loki-primary, Credentials found at `loki_credentials` of json output of terraform-module-cloud-multy-prerequisites
@@ -151,7 +151,7 @@ tempo:
   # -- Part of `loki_s3_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites
   aws_secretKey: placeholder_tempo_aws_secret_key
 
-  prefix: "nonprod.gliese581d.onglueops.rocks/tempo/traces"
+  prefix: "placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain/tempo/traces"
 
   remote_url: ["http://localhost:9090/api/v1/write"]
 


### PR DESCRIPTION
### **PR Type**
enhancement, documentation


___

### **Description**
- Replaced hardcoded domains with dynamic placeholders in `README.md` and `values.yaml` for `loki.prefix`, `tempo.prefix`, and `thanos.prefix`.
- Improved documentation by updating domain references to use placeholders, enhancing flexibility and configurability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Replace hardcoded domains with placeholders in README</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated domain placeholders for <code>loki.prefix</code>, <code>tempo.prefix</code>, and <br><code>thanos.prefix</code>.<br> <li> Replaced hardcoded domain with dynamic placeholders.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/466/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Replace hardcoded domains with placeholders in values.yaml</code></dd></summary>
<hr>

values.yaml

<li>Updated domain placeholders for <code>loki.prefix</code>, <code>tempo.prefix</code>, and <br><code>thanos.prefix</code>.<br> <li> Replaced hardcoded domain with dynamic placeholders.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/466/files#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information