### PR TITLE
feat: updating externalLabel to be captain_domain since it's more use…

### DIFF
--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -86,7 +86,8 @@ spec:
             {{- toYaml .Values.glueops_node_and_tolerations | nindent 12 }}
             replicas: 2
             replicaExternalLabelName: "__replica__"
-            externalLabels: {cluster: "test"}
+            externalLabels:
+              captain_domain: {{ .Values.captain_domain }}
             ruleSelector: {}
             ruleNamespaceSelector: {}
             ruleSelectorNilUsesHelmValues: false


### PR DESCRIPTION
### **User description**
…ful than "test"


___

### **PR Type**
enhancement


___

### **Description**
- Updated the `externalLabels` in the Prometheus configuration to use `captain_domain` from values, replacing the static "test" label.
- This change enhances the flexibility and usefulness of the configuration by allowing dynamic domain specification.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-kube-prometheus-stack.yaml</strong><dd><code>Update externalLabels to use captain_domain dynamically</code>&nbsp; &nbsp; </dd></summary>
<hr>

templates/application-kube-prometheus-stack.yaml

<li>Changed <code>externalLabels</code> to use <code>captain_domain</code> instead of a static <br>value.<br> <li> Updated the configuration to dynamically use <code>.Values.captain_domain</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/552/files#diff-87a59bc30480a9bd9c023721224637a3e2c117ea1b0a2843f98188bc105f3ce3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information