### PR TITLE
Fix rollback external dns. it appears the latest version uses oci repository format

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.53.3
+version: 0.53.4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.53.3](https://img.shields.io/badge/Version-0.53.3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.53.4](https://img.shields.io/badge/Version-0.53.4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://charts.bitnami.com/bitnami'
     chart: external-dns
-    targetRevision: 8.6.0
+    targetRevision: 8.5.1
     helm:
       parameters:
         - name: aws.credentials.secretKey


### PR DESCRIPTION
### **PR Type**
bug_fix, documentation


___

### **Description**
- Rolled back the `external-dns` chart version from 8.6.0 to 8.5.1 to address issues with the latest version using the OCI repository format.
- Updated the chart version in `Chart.yaml` from 0.53.3 to 0.53.4 for a hotfix release.
- Updated the version badge in `README.md` to reflect the new chart version 0.53.4.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Update chart version for hotfix release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Chart.yaml

- Bumped chart version from 0.53.3 to 0.53.4.



</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/572/files#diff-d954583aa4c24cff0039bc948abd7c694fc3dab2030231d11ed1b3cda9b4ddbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update version badge in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

- Updated version badge from 0.53.3 to 0.53.4.



</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/572/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-external-dns.yaml</strong><dd><code>Rollback external-dns chart version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-external-dns.yaml

- Rolled back `external-dns` chart version from 8.6.0 to 8.5.1.



</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/572/files#diff-77f505fbaa80b2ae0f9386fda952a8ed063fc00d35b729f2f24a66b1070900f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information