### PR TITLE
switch `docker.io` to `ghcr.io`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This chart deploys the GlueOps Platform
 | container_images.app_dex.dex.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_dex.dex.image.repository | string | `"dexidp/dex"` |  |
 | container_images.app_dex.dex.image.tag | string | `"v2.41.1@sha256:bc7cfce7c17f52864e2bb2a4dc1d2f86a41e3019f6d42e81d92a301fad0c8a1d"` |  |
-| container_images.app_fluent_operator.kubesphere.image.registry | string | `"docker.io"` |  |
+| container_images.app_fluent_operator.kubesphere.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_fluent_operator.kubesphere.image.repository | string | `"kubesphere/fluent-operator"` |  |
 | container_images.app_fluent_operator.kubesphere.image.tag | string | `"v2.7.0@sha256:b0668c0d878bde4ab04802a7e92d0dd3bef4c1fed1b5e63cf83d49bb3c5d3947"` |  |
 | container_images.app_glueops_alerts.cluster_monitoring.image.registry | string | `"ghcr.io"` |  |
@@ -38,10 +38,10 @@ This chart deploys the GlueOps Platform
 | container_images.app_ingress_nginx.controller.image.registry | string | `"registry.k8s.io"` |  |
 | container_images.app_ingress_nginx.controller.image.repository | string | `"ingress-nginx/controller"` |  |
 | container_images.app_ingress_nginx.controller.image.tag | string | `"v1.11.4@sha256:981a97d78bee3109c0b149946c07989f8f1478a9265031d2d23dea839ba05b52"` |  |
-| container_images.app_kube_prometheus_stack.grafana.image.registry | string | `"docker.io"` |  |
+| container_images.app_kube_prometheus_stack.grafana.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_kube_prometheus_stack.grafana.image.repository | string | `"grafana/grafana"` |  |
 | container_images.app_kube_prometheus_stack.grafana.image.tag | string | `"10.4.13@sha256:c8644d0d41757dd444bd1aabc23740be71f0a34549128454a2b37f57a0c496b0"` |  |
-| container_images.app_loki.loki.image.registry | string | `"docker.io"` |  |
+| container_images.app_loki.loki.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_loki.loki.image.repository | string | `"grafana/loki"` |  |
 | container_images.app_loki.loki.image.tag | string | `"2.9.10@sha256:35b02acc67654ddc38273e519b4f26f3967a907b9db5489af300c21f37ee1ae7"` |  |
 | container_images.app_loki_alert_group_controller.loki_alert_group_controller.image.registry | string | `"ghcr.io"` |  |
@@ -50,10 +50,10 @@ This chart deploys the GlueOps Platform
 | container_images.app_metacontroller.metacontroller.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_metacontroller.metacontroller.image.repository | string | `"metacontroller/metacontroller"` |  |
 | container_images.app_metacontroller.metacontroller.image.tag | string | `"v4.11.22@sha256:eaa81a295876608f9098f08bd722e86ce4598a455b44f1d318a89866606dac85"` |  |
-| container_images.app_network_exporter.network_exporter.image.registry | string | `"docker.io"` |  |
+| container_images.app_network_exporter.network_exporter.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_network_exporter.network_exporter.image.repository | string | `"syepes/network_exporter"` |  |
 | container_images.app_network_exporter.network_exporter.image.tag | string | `"1.7.9@sha256:36cd647c80c30e3f5b78f9d2ca60f38e1d024fb3b9588a845cac2dc3f4fb75e1"` |  |
-| container_images.app_promtail.promtail.image.registry | string | `"docker.io"` |  |
+| container_images.app_promtail.promtail.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_promtail.promtail.image.repository | string | `"grafana/promtail"` |  |
 | container_images.app_promtail.promtail.image.tag | string | `"2.9.10@sha256:63a2e57a5b1401109f77d36a49a637889d431280ed38f5f885eedcd3949e52cf"` |  |
 | container_images.app_pull_request_bot.pull_request_bot.image.registry | string | `"ghcr.io"` |  |
@@ -62,7 +62,7 @@ This chart deploys the GlueOps Platform
 | container_images.app_qr_code_generator.qr_code_generator.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_qr_code_generator.qr_code_generator.image.repository | string | `"glueops/qr-code-generator"` |  |
 | container_images.app_qr_code_generator.qr_code_generator.image.tag | string | `"v0.7.1@sha256:884d67d4e17f3c4567dcb79eb3491099c448b58dc0c81ae848b50cd8cf314d22"` |  |
-| container_images.app_vault.vault.image.registry | string | `"docker.io"` |  |
+| container_images.app_vault.vault.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_vault.vault.image.repository | string | `"hashicorp/vault"` |  |
 | container_images.app_vault.vault.image.tag | string | `"1.14.10@sha256:14be0a8eb323181a56d10facab3b424809d9921e85d2f2678126ce232766a8e1"` |  |
 | container_images.app_vault_init_controller.vault_init_controller.image.registry | string | `"ghcr.io"` |  |

--- a/values.yaml
+++ b/values.yaml
@@ -267,7 +267,7 @@ container_images:
   app_kube_prometheus_stack:
     grafana:
       image:
-        registry: docker.io
+        registry: ghcr.io
         repository: grafana/grafana
         tag: 10.4.13@sha256:c8644d0d41757dd444bd1aabc23740be71f0a34549128454a2b37f57a0c496b0
   app_loki_alert_group_controller:
@@ -279,19 +279,19 @@ container_images:
   app_loki:
     loki:
       image:
-        registry: docker.io
+        registry: ghcr.io
         repository: grafana/loki
         tag: 2.9.10@sha256:35b02acc67654ddc38273e519b4f26f3967a907b9db5489af300c21f37ee1ae7
   app_network_exporter:
     network_exporter:
       image:
-        registry: docker.io # not actually used
+        registry: ghcr.io # not actually used
         repository: syepes/network_exporter
         tag: 1.7.9@sha256:36cd647c80c30e3f5b78f9d2ca60f38e1d024fb3b9588a845cac2dc3f4fb75e1
   app_promtail:
     promtail:
       image:
-        registry: docker.io
+        registry: ghcr.io
         repository: grafana/promtail
         tag: 2.9.10@sha256:63a2e57a5b1401109f77d36a49a637889d431280ed38f5f885eedcd3949e52cf
   app_pull_request_bot:
@@ -315,7 +315,7 @@ container_images:
   app_vault:
     vault:
       image:
-        registry: docker.io # not actually used
+        registry: ghcr.io # not actually used
         repository: hashicorp/vault
         tag: 1.14.10@sha256:14be0a8eb323181a56d10facab3b424809d9921e85d2f2678126ce232766a8e1
   app_metacontroller:
@@ -327,7 +327,7 @@ container_images:
   app_fluent_operator:
     kubesphere:
       image:
-        registry: docker.io
+        registry: ghcr.io
         repository: kubesphere/fluent-operator
         tag: v2.7.0@sha256:b0668c0d878bde4ab04802a7e92d0dd3bef4c1fed1b5e63cf83d49bb3c5d3947
   app_ingress_nginx:


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated container image registries from `docker.io` to `ghcr.io`.

- Modified references in `README.md` and `values.yaml` files.

- Ensured consistency across multiple container images configurations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update container image registry references in documentation</code></dd></summary>
<hr>

README.md

<li>Updated container image registry references from <code>docker.io</code> to <code>ghcr.io</code>.<br> <li> Adjusted multiple container image configurations for consistency.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/624/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Update container image registry references in configuration</code></dd></summary>
<hr>

values.yaml

<li>Replaced <code>docker.io</code> with <code>ghcr.io</code> for container image registries.<br> <li> Updated comments to reflect registry changes.<br> <li> Ensured consistency across container image configurations.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/624/files#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7e">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>