### PR TITLE
Change registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,64 +8,47 @@ This chart deploys the GlueOps Platform
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| base_registry | string | `"ghcr.io/glueops/mirror"` |  |
 | captain_domain | string | `"placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain"` | The Route53 subdomain for the services on your cluster. It will be used as the suffix url for argocd, grafana, vault, and any other services that come out of the box in the glueops platform. Note: you need to create this before using this repo as this repo does not provision DNS Zones for you. This is the domain you created through: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | captain_repo.private_b64enc_deploy_key | string | `"placeholder_captain_repo_b64enc_private_deploy_key"` | This is a read only deploy key that will be used to read the captain repo. Part of output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | captain_repo.ssh_clone_url | string | `"placeholder_captain_repo_ssh_clone_url"` | This is the github url of the captain repo https://github.com/glueops/development-captains/tenant . Part of output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | certManager.aws_accessKey | string | `"placeholder_certmanager_aws_access_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | certManager.aws_region | string | `"placeholder_aws_region"` | Should be the same `primary_region` you used in: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | certManager.aws_secretKey | string | `"placeholder_certmanager_aws_secret_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
-| container_images.app_backup_and_exports.backup_tools.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.repository | string | `"glueops/backup-tools"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.tag | string | `"v0.18.1@sha256:1167387e74ad4be14b77abfb122d91a018ea284152c9c0da822027cdde482ea0"` |  |
-| container_images.app_backup_and_exports.certs_backup_restore.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_backup_and_exports.certs_backup_restore.image.repository | string | `"glueops/certs-backup-restore"` |  |
 | container_images.app_backup_and_exports.certs_backup_restore.image.tag | string | `"v0.10.2@sha256:6d402e2a7a39d8dcf1e93da3fb305f4756cf5fa9ea2b2ae639655c5f8e8963a9"` |  |
-| container_images.app_backup_and_exports.vault_backup_validator.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_backup_and_exports.vault_backup_validator.image.repository | string | `"glueops/vault-backup-validator"` |  |
 | container_images.app_backup_and_exports.vault_backup_validator.image.tag | string | `"v0.3.5@sha256:6a309b82a56edf90995c4ace14fbbbf992d8017a0188f610726d403f2699bea7"` |  |
-| container_images.app_cluster_info_page.cluster_information_help_page_html.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_cluster_info_page.cluster_information_help_page_html.image.repository | string | `"glueops/cluster-information-help-page-html"` |  |
 | container_images.app_cluster_info_page.cluster_information_help_page_html.image.tag | string | `"v0.4.5@sha256:5f1843dfa2f76eea0a5e9a792867305d50b6f2d27e010d003a9ce79eb4188d16"` |  |
-| container_images.app_dex.dex.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_dex.dex.image.repository | string | `"dexidp/dex"` |  |
 | container_images.app_dex.dex.image.tag | string | `"v2.41.1@sha256:bc7cfce7c17f52864e2bb2a4dc1d2f86a41e3019f6d42e81d92a301fad0c8a1d"` |  |
-| container_images.app_fluent_operator.kubesphere.image.registry | string | `"docker.io"` |  |
 | container_images.app_fluent_operator.kubesphere.image.repository | string | `"kubesphere/fluent-operator"` |  |
 | container_images.app_fluent_operator.kubesphere.image.tag | string | `"v2.7.0@sha256:b0668c0d878bde4ab04802a7e92d0dd3bef4c1fed1b5e63cf83d49bb3c5d3947"` |  |
-| container_images.app_glueops_alerts.cluster_monitoring.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_glueops_alerts.cluster_monitoring.image.repository | string | `"glueops/cluster-monitoring"` |  |
 | container_images.app_glueops_alerts.cluster_monitoring.image.tag | string | `"v0.8.1@sha256:aa12c39244682d61a48fc374f97f318943c42c36347bf333105c5f4802721419"` |  |
-| container_images.app_ingress_nginx.controller.image.registry | string | `"registry.k8s.io"` |  |
 | container_images.app_ingress_nginx.controller.image.repository | string | `"ingress-nginx/controller"` |  |
 | container_images.app_ingress_nginx.controller.image.tag | string | `"v1.11.4@sha256:981a97d78bee3109c0b149946c07989f8f1478a9265031d2d23dea839ba05b52"` |  |
-| container_images.app_kube_prometheus_stack.grafana.image.registry | string | `"docker.io"` |  |
 | container_images.app_kube_prometheus_stack.grafana.image.repository | string | `"grafana/grafana"` |  |
 | container_images.app_kube_prometheus_stack.grafana.image.tag | string | `"10.4.13@sha256:c8644d0d41757dd444bd1aabc23740be71f0a34549128454a2b37f57a0c496b0"` |  |
-| container_images.app_loki.loki.image.registry | string | `"docker.io"` |  |
 | container_images.app_loki.loki.image.repository | string | `"grafana/loki"` |  |
 | container_images.app_loki.loki.image.tag | string | `"2.9.10@sha256:35b02acc67654ddc38273e519b4f26f3967a907b9db5489af300c21f37ee1ae7"` |  |
-| container_images.app_loki_alert_group_controller.loki_alert_group_controller.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_loki_alert_group_controller.loki_alert_group_controller.image.repository | string | `"glueops/metacontroller-operator-loki-rule-group"` |  |
 | container_images.app_loki_alert_group_controller.loki_alert_group_controller.image.tag | string | `"v0.4.6@sha256:61aa2e48fd5c2277551daca68f287e77530a357d280a8199a5db5724b255401c"` |  |
-| container_images.app_metacontroller.metacontroller.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_metacontroller.metacontroller.image.repository | string | `"metacontroller/metacontroller"` |  |
 | container_images.app_metacontroller.metacontroller.image.tag | string | `"v4.11.22@sha256:eaa81a295876608f9098f08bd722e86ce4598a455b44f1d318a89866606dac85"` |  |
-| container_images.app_network_exporter.network_exporter.image.registry | string | `"docker.io"` |  |
 | container_images.app_network_exporter.network_exporter.image.repository | string | `"syepes/network_exporter"` |  |
 | container_images.app_network_exporter.network_exporter.image.tag | string | `"1.7.9@sha256:36cd647c80c30e3f5b78f9d2ca60f38e1d024fb3b9588a845cac2dc3f4fb75e1"` |  |
-| container_images.app_promtail.promtail.image.registry | string | `"docker.io"` |  |
 | container_images.app_promtail.promtail.image.repository | string | `"grafana/promtail"` |  |
 | container_images.app_promtail.promtail.image.tag | string | `"2.9.10@sha256:63a2e57a5b1401109f77d36a49a637889d431280ed38f5f885eedcd3949e52cf"` |  |
-| container_images.app_pull_request_bot.pull_request_bot.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_pull_request_bot.pull_request_bot.image.repository | string | `"glueops/pull-request-bot"` |  |
 | container_images.app_pull_request_bot.pull_request_bot.image.tag | string | `"v0.22.2@sha256:e9217e3f5451a577c6df9583d70b05d08d7222941587d243486436ffba638c7f"` |  |
-| container_images.app_qr_code_generator.qr_code_generator.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_qr_code_generator.qr_code_generator.image.repository | string | `"glueops/qr-code-generator"` |  |
 | container_images.app_qr_code_generator.qr_code_generator.image.tag | string | `"v0.7.1@sha256:884d67d4e17f3c4567dcb79eb3491099c448b58dc0c81ae848b50cd8cf314d22"` |  |
-| container_images.app_vault.vault.image.registry | string | `"docker.io"` |  |
 | container_images.app_vault.vault.image.repository | string | `"hashicorp/vault"` |  |
 | container_images.app_vault.vault.image.tag | string | `"1.14.10@sha256:14be0a8eb323181a56d10facab3b424809d9921e85d2f2678126ce232766a8e1"` |  |
-| container_images.app_vault_init_controller.vault_init_controller.image.registry | string | `"ghcr.io"` |  |
 | container_images.app_vault_init_controller.vault_init_controller.image.repository | string | `"glueops/vault-init-controller"` |  |
 | container_images.app_vault_init_controller.vault_init_controller.image.tag | string | `"v0.8.1@sha256:9390672242268a812022cc736f0cc7e3506ddb94856c56eab0eb7f59a2b12b6e"` |  |
 | daemonset_tolerations[0].effect | string | `"NoSchedule"` |  |

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -68,7 +68,7 @@ spec:
             apiGroup: rbac.authorization.k8s.io
 
         image:
-          registry: {{ .Values.container_images.app_backup_and_exports.vault_backup_validator.image.registry }}
+          registry: {{ .Values.base_registry }}
           repository: {{ .Values.container_images.app_backup_and_exports.vault_backup_validator.image.repository }}
           tag: {{ .Values.container_images.app_backup_and_exports.vault_backup_validator.image.tag }}
   
@@ -97,7 +97,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: {{ .Values.container_images.app_backup_and_exports.backup_tools.image.registry }}/{{ .Values.container_images.app_backup_and_exports.backup_tools.image.repository }}:{{ .Values.container_images.app_backup_and_exports.backup_tools.image.tag }}
+              image: {{ .Values.base_registry }}/{{ .Values.container_images.app_backup_and_exports.backup_tools.image.repository }}:{{ .Values.container_images.app_backup_and_exports.backup_tools.image.tag }}
               command: ["/bin/bash", "-c"]
               args:
                 - backup-vault
@@ -138,7 +138,7 @@ spec:
               concurrencyPolicy: Forbid
               successfulJobsHistoryLimit: 10
               failedJobsHistoryLimit: 3
-              image: {{ .Values.container_images.app_backup_and_exports.certs_backup_restore.image.registry }}/{{ .Values.container_images.app_backup_and_exports.certs_backup_restore.image.repository }}:{{ .Values.container_images.app_backup_and_exports.certs_backup_restore.image.tag }}
+              image: {{ .Values.base_registry }}/{{ .Values.container_images.app_backup_and_exports.certs_backup_restore.image.repository }}:{{ .Values.container_images.app_backup_and_exports.certs_backup_restore.image.tag }}
               command: ["python", "-u", "/app/cert-backup-restore/main.py","--backup"]
               resources:
                 requests:

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -61,6 +61,16 @@ spec:
           value: "{{ .Values.tls_cert_restore.backup_prefix }}"
         - name: cert-restore.exclude_namespaces
           value: "{{ .Values.tls_cert_restore.exclude_namespaces }}"
+        - name: cert-manager.image.repository
+          value: {{ .Values.base_registry }}/jetstack/cert-manager-controller
+        - name: cert-manager.webhook.image.repository
+          value: {{ .Values.base_registry }}/jetstack/cert-manager-webhook
+        - name: cert-manager.cainjector.image.repository
+          value: {{ .Values.base_registry }}/jetstack/cert-manager-cainjector
+        - name: cert-manager.acmesolver.image.repository
+          value: {{ .Values.base_registry }}/jetstack/cert-manager-acmesolver
+        - name: cert-manager.startupapicheck.image.repository
+          value: {{ .Values.base_registry }}/jetstack/cert-manager-startupapicheck
       values: |-
         cert-manager:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}

--- a/templates/application-cluster-info-page.yaml
+++ b/templates/application-cluster-info-page.yaml
@@ -31,7 +31,7 @@ spec:
 
       
         image:
-          registry: {{ .Values.container_images.app_cluster_info_page.cluster_information_help_page_html.image.registry }}
+          registry: {{ .Values.base_registry }}
           repository: {{ .Values.container_images.app_cluster_info_page.cluster_information_help_page_html.image.repository }}
           tag: {{ .Values.container_images.app_cluster_info_page.cluster_information_help_page_html.image.tag }}
           pullPolicy: IfNotPresent

--- a/templates/application-dex.yaml
+++ b/templates/application-dex.yaml
@@ -32,7 +32,7 @@ spec:
       values: |
         {{- toYaml .Values.glueops_node_and_tolerations | nindent 8 }}
         image:
-          repository: {{ .Values.container_images.app_dex.dex.image.registry }}/{{ .Values.container_images.app_dex.dex.image.repository }}
+          repository: {{ .Values.base_registry }}/{{ .Values.container_images.app_dex.dex.image.repository }}
           tag: {{ .Values.container_images.app_dex.dex.image.tag }}
         ingress:
           enabled: true

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -39,6 +39,10 @@ spec:
           value: {{ .Values.captain_domain }}
         - name: policy
           value: sync
+        - name: global.imageRegistry
+          value: {{ .Values.base_registry }}
+        - name: global.security.allowInsecureImages
+          value: "true"
         - name: provider
           value: aws
         - name: aws.preferCNAME

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -34,6 +34,18 @@ spec:
           value: "{{ .Values.host_network.enabled }}"
         - name: external-secrets.webhook.port
           value: "{{ .Values.host_network.external_secrets.webhook_port }}"
+        - name: external-secrets.image.repository
+          value: "{{ .Values.base_registry }}/{{ .Values.container_images.app_external_secrets.external_secrets.image.repository }}"
+        - name: external-secrets.image.tag
+          value: "{{ .Values.container_images.app_external_secrets.external_secrets.image.tag }}"
+        - name: external-secrets.webhook.image.repository
+          value: "{{ .Values.base_registry }}/{{ .Values.container_images.app_external_secrets.external_secrets.image.repository }}"
+        - name: external-secrets.webhook.image.tag
+          value: "{{ .Values.container_images.app_external_secrets.external_secrets.image.tag }}"
+        - name: external-secrets.certController.image.repository
+          value: "{{ .Values.base_registry }}/{{ .Values.container_images.app_external_secrets.external_secrets.image.repository }}"
+        - name: external-secrets.certController.image.tag
+          value: "{{ .Values.container_images.app_external_secrets.external_secrets.image.tag }}"
       values: |
         external-secrets:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}

--- a/templates/application-fluent-operator.yaml
+++ b/templates/application-fluent-operator.yaml
@@ -34,8 +34,8 @@ spec:
               {{- toYaml .Values.glueops_node_and_tolerations.tolerations | nindent 12 }}
             container:
               registry: {{ .Values.base_registry }}
-              repository: {{ .Values.container_images.app_fluent_operator.kubeshpere.image.repository }}
-              tag: {{ .Values.container_images.app_fluent_operator.kubeshpere.image.tag }}
+              repository: {{ .Values.container_images.app_fluent_operator.kubesphere.image.repository }}
+              tag: {{ .Values.container_images.app_fluent_operator.kubesphere.image.tag }}
           fluentbit:
             hostNetwork: true
             enable: false

--- a/templates/application-fluent-operator.yaml
+++ b/templates/application-fluent-operator.yaml
@@ -33,8 +33,7 @@ spec:
             tolerations:
               {{- toYaml .Values.glueops_node_and_tolerations.tolerations | nindent 12 }}
             container:
-              registry: {{ .Values.base_registry }}
-              repository: {{ .Values.container_images.app_fluent_operator.kubesphere.image.repository }}
+              repository: {{ .Values.base_registry }}/{{ .Values.container_images.app_fluent_operator.kubesphere.image.repository }}
               tag: {{ .Values.container_images.app_fluent_operator.kubesphere.image.tag }}
           fluentbit:
             hostNetwork: true

--- a/templates/application-fluent-operator.yaml
+++ b/templates/application-fluent-operator.yaml
@@ -33,7 +33,7 @@ spec:
             tolerations:
               {{- toYaml .Values.glueops_node_and_tolerations.tolerations | nindent 12 }}
             container:
-              registry: {{ .Values.container_images.app_fluent_operator.kubeshpere.image.registry }}
+              registry: {{ .Values.base_registry }}
               repository: {{ .Values.container_images.app_fluent_operator.kubeshpere.image.repository }}
               tag: {{ .Values.container_images.app_fluent_operator.kubeshpere.image.tag }}
           fluentbit:

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -33,7 +33,7 @@ spec:
         appName: 'glueops-core-alerts'
 
         image:
-          registry: {{ .Values.container_images.app_glueops_alerts.cluster_monitoring.image.registry }}
+          registry: {{ .Values.base_registry }}
           repository: {{ .Values.container_images.app_glueops_alerts.cluster_monitoring.image.repository }}
           tag: {{ .Values.container_images.app_glueops_alerts.cluster_monitoring.image.tag }}
           pullPolicy: IfNotPresent

--- a/templates/application-keda.yaml
+++ b/templates/application-keda.yaml
@@ -66,3 +66,6 @@ spec:
             port:  {{ .Values.host_network.keda.webhooks.port }}
             healthProbePort: {{ .Values.host_network.keda.webhooks.healthProbePort }}
             useHostNetwork: {{ .Values.host_network.enabled }}
+        global:
+          image:
+            registry: {{ .Values.base_registry }}

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -96,7 +96,7 @@ spec:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           adminPassword: "{{ .Values.grafana.admin_password }}"
           image:
-            registry: {{ .Values.container_images.app_kube_prometheus_stack.grafana.image.registry }}
+            registry: {{ .Values.base_registry }}
             repository: {{ .Values.container_images.app_kube_prometheus_stack.grafana.image.repository }}
             tag: {{ .Values.container_images.app_kube_prometheus_stack.grafana.image.tag }}
           #https://stackoverflow.com/questions/77912105/upgrading-kube-prometheus-stack-via-helm-to-chart-v56-2-1-fails-on-grafana-with

--- a/templates/application-loki-alert-group-controller.yaml
+++ b/templates/application-loki-alert-group-controller.yaml
@@ -31,7 +31,7 @@ spec:
       values: |
         appName: '{{ .Release.Name }}'
         image:
-          registry: {{ .Values.container_images.app_loki_alert_group_controller.loki_alert_group_controller.image.registry }}
+          registry: {{ .Values.base_registry }}
           repository: {{ .Values.container_images.app_loki_alert_group_controller.loki_alert_group_controller.image.repository }}
           tag: {{ .Values.container_images.app_loki_alert_group_controller.loki_alert_group_controller.image.tag }}
           pullPolicy: IfNotPresent

--- a/templates/application-loki.yaml
+++ b/templates/application-loki.yaml
@@ -30,7 +30,7 @@ spec:
     helm:
       parameters:
         - name: loki.image.registry
-          value: '{{ .Values.container_images.app_loki.loki.image.registry }}'
+          value: '{{ .Values.base_registry }}'
         - name: loki.image.repository
           value: '{{ .Values.container_images.app_loki.loki.image.repository }}'
         - name: loki.image.tag

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -45,5 +45,5 @@ spec:
           - --workers=100
 
         image:
-          repository: {{ .Values.container_images.app_metacontroller.metacontroller.image.registry }}/{{ .Values.container_images.app_metacontroller.metacontroller.image.repository }}
+          repository: {{ .Values.base_registry }}/{{ .Values.container_images.app_metacontroller.metacontroller.image.repository }}
           tag: {{ .Values.container_images.app_metacontroller.metacontroller.image.tag }}

--- a/templates/application-network-exporter.yaml
+++ b/templates/application-network-exporter.yaml
@@ -54,7 +54,7 @@ spec:
                     - --config.file=/config/config.yml
                     command:
                     - /app/network_exporter
-                    image: {{ .Values.container_images.app_network_exporter.network_exporter.image.registry }}/{{ .Values.container_images.app_network_exporter.network_exporter.image.repository }}:{{ .Values.container_images.app_network_exporter.network_exporter.image.tag }}
+                    image: {{ .Values.base_registry }}/{{ .Values.container_images.app_network_exporter.network_exporter.image.repository }}:{{ .Values.container_images.app_network_exporter.network_exporter.image.tag }}
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       failureThreshold: 3

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -31,7 +31,7 @@ spec:
       values: |-
         controller:
           image:
-            registry: {{ .Values.container_images.app_ingress_nginx.controller.image.registry }}
+            registry: {{ .Values.base_registry }}
             image: {{ .Values.container_images.app_ingress_nginx.controller.image.repository }}
             tag: {{ .Values.container_images.app_ingress_nginx.controller.image.tag }}
             digest: ""

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -29,7 +29,17 @@ spec:
     targetRevision: 4.11.4
     helm:
       values: |-
+        defaultBackend:
+          image:
+            registry: {{ .Values.base_registry }}
         controller:
+          admissionWebhooks:
+            patch:
+              image:
+                registry: {{ .Values.base_registry }}
+          opentelemetry:
+            image:
+              registry: {{ .Values.base_registry }}
           image:
             registry: {{ .Values.base_registry }}
             image: {{ .Values.container_images.app_ingress_nginx.controller.image.repository }}

--- a/templates/application-promtail.yaml
+++ b/templates/application-promtail.yaml
@@ -33,7 +33,7 @@ spec:
           value: http://loki-write.glueops-core-loki.svc.cluster.local:3100/loki/api/v1/push
       values: |-
         image:
-          registry: {{ .Values.container_images.app_promtail.promtail.image.registry }}
+          registry: {{ .Values.base_registry }}
           repository: {{ .Values.container_images.app_promtail.promtail.image.repository }}
           tag: {{ .Values.container_images.app_promtail.promtail.image.tag }}
         tolerations:

--- a/templates/application-pull-request-bot.yaml
+++ b/templates/application-pull-request-bot.yaml
@@ -30,7 +30,7 @@ spec:
       values: |
         appName: 'pull-request-bot'
         image:
-          registry: {{ .Values.container_images.app_pull_request_bot.pull_request_bot.image.registry }}
+          registry: {{ .Values.base_registry }}
           repository: {{ .Values.container_images.app_pull_request_bot.pull_request_bot.image.repository }}
           tag: {{ .Values.container_images.app_pull_request_bot.pull_request_bot.image.tag }}
           pullPolicy: IfNotPresent

--- a/templates/application-qr-code-generator.yaml
+++ b/templates/application-qr-code-generator.yaml
@@ -31,7 +31,7 @@ spec:
         appName: 'qr-code-generator'
         replicaCount: '2'
         image:
-          registry: {{ .Values.container_images.app_qr_code_generator.qr_code_generator.image.registry }}
+          registry: {{ .Values.base_registry }}
           repository: {{ .Values.container_images.app_qr_code_generator.qr_code_generator.image.repository }}
           tag: {{ .Values.container_images.app_qr_code_generator.qr_code_generator.image.tag }}
           pullPolicy: IfNotPresent

--- a/templates/application-vault-init-controller.yaml
+++ b/templates/application-vault-init-controller.yaml
@@ -29,7 +29,7 @@ spec:
       values: |
         appName: 'vault-init-controller'
         image:
-          registry: {{ .Values.container_images.app_vault_init_controller.vault_init_controller.image.registry }}
+          registry: {{ .Values.base_registry }}
           repository: {{ .Values.container_images.app_vault_init_controller.vault_init_controller.image.repository }}
           tag: {{ .Values.container_images.app_vault_init_controller.vault_init_controller.image.tag }}
         serviceAccount:

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -44,7 +44,7 @@ spec:
         server:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
           image:
-            repository: {{ .Values.container_images.app_vault.vault.image.repository }}
+            repository: {{ .Values.base_registry }}/{{ .Values.container_images.app_vault.vault.image.repository }}
             tag: {{ .Values.container_images.app_vault.vault.image.tag }}
           updateStrategyType: "RollingUpdate"
           dataStorage:

--- a/values.yaml
+++ b/values.yaml
@@ -229,111 +229,94 @@ tls_cert_restore:
   backup_prefix: placeholder_tls_cert_backup_s3_key_prefix
   exclude_namespaces: placeholder_tls_cert_restore_exclude_namespaces
 
+base_registry: ghcr.io/glueops/mirror
 container_images:
   app_backup_and_exports:
     vault_backup_validator:
       image:
-        registry: ghcr.io
         repository: glueops/vault-backup-validator
         tag: v0.3.5@sha256:6a309b82a56edf90995c4ace14fbbbf992d8017a0188f610726d403f2699bea7
     backup_tools:
       image:
-        registry: ghcr.io
         repository: glueops/backup-tools
         tag: v0.18.1@sha256:1167387e74ad4be14b77abfb122d91a018ea284152c9c0da822027cdde482ea0
     certs_backup_restore:
       image:
-        registry: ghcr.io
         repository: glueops/certs-backup-restore
         tag: v0.10.2@sha256:6d402e2a7a39d8dcf1e93da3fb305f4756cf5fa9ea2b2ae639655c5f8e8963a9
   app_cluster_info_page:
     cluster_information_help_page_html:
       image:
-        registry: ghcr.io
         repository: glueops/cluster-information-help-page-html
         tag: v0.4.5@sha256:5f1843dfa2f76eea0a5e9a792867305d50b6f2d27e010d003a9ce79eb4188d16
   app_dex:
     dex:
       image:
-        registry: ghcr.io
         repository: dexidp/dex
         tag: v2.41.1@sha256:bc7cfce7c17f52864e2bb2a4dc1d2f86a41e3019f6d42e81d92a301fad0c8a1d
   app_glueops_alerts:
     cluster_monitoring:
       image:
-        registry: ghcr.io
         repository: glueops/cluster-monitoring
         tag: v0.8.1@sha256:aa12c39244682d61a48fc374f97f318943c42c36347bf333105c5f4802721419
   app_kube_prometheus_stack:
     grafana:
       image:
-        registry: docker.io
         repository: grafana/grafana
         tag: 10.4.13@sha256:c8644d0d41757dd444bd1aabc23740be71f0a34549128454a2b37f57a0c496b0
   app_loki_alert_group_controller:
     loki_alert_group_controller:
       image:
-        registry: ghcr.io
         repository: glueops/metacontroller-operator-loki-rule-group
         tag: v0.4.6@sha256:61aa2e48fd5c2277551daca68f287e77530a357d280a8199a5db5724b255401c
   app_loki:
     loki:
       image:
-        registry: docker.io
         repository: grafana/loki
         tag: 2.9.10@sha256:35b02acc67654ddc38273e519b4f26f3967a907b9db5489af300c21f37ee1ae7
   app_network_exporter:
     network_exporter:
       image:
-        registry: docker.io # not actually used
         repository: syepes/network_exporter
         tag: 1.7.9@sha256:36cd647c80c30e3f5b78f9d2ca60f38e1d024fb3b9588a845cac2dc3f4fb75e1
   app_promtail:
     promtail:
       image:
-        registry: docker.io
         repository: grafana/promtail
         tag: 2.9.10@sha256:63a2e57a5b1401109f77d36a49a637889d431280ed38f5f885eedcd3949e52cf
   app_pull_request_bot:
     pull_request_bot:
       image:
-        registry: ghcr.io
         repository: glueops/pull-request-bot
         tag: v0.22.2@sha256:e9217e3f5451a577c6df9583d70b05d08d7222941587d243486436ffba638c7f
   app_qr_code_generator:
     qr_code_generator:
       image: 
-        registry: ghcr.io
         repository: glueops/qr-code-generator
         tag: v0.7.1@sha256:884d67d4e17f3c4567dcb79eb3491099c448b58dc0c81ae848b50cd8cf314d22
   app_vault_init_controller:
     vault_init_controller:
       image:
-        registry: ghcr.io
         repository: glueops/vault-init-controller
         tag: v0.8.1@sha256:9390672242268a812022cc736f0cc7e3506ddb94856c56eab0eb7f59a2b12b6e
   app_vault:
     vault:
       image:
-        registry: docker.io # not actually used
         repository: hashicorp/vault
         tag: 1.14.10@sha256:14be0a8eb323181a56d10facab3b424809d9921e85d2f2678126ce232766a8e1
   app_metacontroller:
     metacontroller:
       image:
-        registry: ghcr.io
         repository: metacontroller/metacontroller
         tag: v4.11.22@sha256:eaa81a295876608f9098f08bd722e86ce4598a455b44f1d318a89866606dac85 #this might need to be updated manually because of renovatebot errors
   app_fluent_operator:
     kubesphere:
       image:
-        registry: docker.io
         repository: kubesphere/fluent-operator
         tag: v2.7.0@sha256:b0668c0d878bde4ab04802a7e92d0dd3bef4c1fed1b5e63cf83d49bb3c5d3947
   app_ingress_nginx:
     controller:
       image:
-        registry: registry.k8s.io
         repository: ingress-nginx/controller
         tag: v1.11.4@sha256:981a97d78bee3109c0b149946c07989f8f1478a9265031d2d23dea839ba05b52
 

--- a/values.yaml
+++ b/values.yaml
@@ -231,6 +231,11 @@ tls_cert_restore:
 
 base_registry: ghcr.io/glueops/mirror
 container_images:
+  app_external_secrets:
+    external_secrets:
+      image:
+        repository: external-secrets/external-secrets
+        tag: v0.9.20
   app_backup_and_exports:
     vault_backup_validator:
       image:


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduced a new `base_registry` variable for centralized image registry configuration.

- Updated Helm templates to use `base_registry` instead of individual image registry definitions.

- Removed redundant `registry` fields from `values.yaml` for cleaner configuration.

- Updated documentation in `README.md` to reflect the new `base_registry` variable.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Documented the new `base_registry` variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-18</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>application-backups-and-exports.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-b8741a1ff9ee30514ce50acd27aaab4531d5402c104bf8d28e0404d9b1f43a8c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-cluster-info-page.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-4a288ee2dd2d1485fadbc05092c140f3df4ae6a1bb7c8152660147a540e86686">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-dex.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-0223e317adb6b65f63f9323ffa9d74ff8da3f84cbdead0c73b8afa0ebdb70ffd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-fluent-operator.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-80ca21150612f3908943d9b7988be03e5aaba44936c3a78cd388c47a3ae8c8c5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-glueops-alerts.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-360ed6e9dd855672acb53925c0ab6cce214159e7d5d293114a89b60757ba887e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-kube-prometheus-stack.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-87a59bc30480a9bd9c023721224637a3e2c117ea1b0a2843f98188bc105f3ce3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-loki-alert-group-controller.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-09fc427726cfb518f847f06ab0888b91dc9ed880eb3455c69e7de0e08f4e44ee">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-loki.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-35d196c1e2f73b4c5bae7a929e46ae128a109d728fe4b5fa588e5ebd1853134b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-metacontroller.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-ad91a818a3e321ad5e3a873b4bf5d6a443366295bf315ef4b790bcc99c4f00a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-network-exporter.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-ee26c9a4329aa0874b28a9aadcc4a83a9268189c03c3e31fc94013ab92b43b4b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-nginx-public.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-b8951700ccd41112fa2d2a037fe78e1b4f6e49da48fc3592c0605afdad3c15cc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-promtail.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-9214e9cc299a32be849e6e9b3d1ade7f937a12b1b06d6be9327ef03dfd9438e4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-pull-request-bot.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-7e4edd3e2254c967df8fa1e2864df1fc07fe03327efbe1fb36e92bd332ae6f8a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-qr-code-generator.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-78cf2195e956cb1d4d7052085ba03b1923bfef65ef547778ded8805bb31d0199">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application-vault-init-controller.yaml</strong><dd><code>Updated image registry references to use `base_registry`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-42aebb2879ee0b37491aae9be9f84965f0c3c50e5872eeae3bc901cc28e13a2c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>values.yaml</strong><dd><code>Added `base_registry` and removed redundant `registry` fields</code></dd></td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/630/files#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7e">+1/-18</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>