### PR TITLE
fix: downgrading vault back to old version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.1.0
 description: This chart deploys the GlueOps Platform
 name: glueops-platform
-version: 0.56.3
+version: 0.56.4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-platform
 
-![Version: 0.56.3](https://img.shields.io/badge/Version-0.56.3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.56.4](https://img.shields.io/badge/Version-0.56.4-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 This chart deploys the GlueOps Platform
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the chart version in `Chart.yaml` to 0.56.4.

- Incremented version likely for a minor update or fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Incremented chart version in Helm configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Chart.yaml

<li>Updated the <code>version</code> field from 0.56.3 to 0.56.4.<br> <li> No other changes were made in the file.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/682/files#diff-d954583aa4c24cff0039bc948abd7c694fc3dab2030231d11ed1b3cda9b4ddbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>