### PR TITLE
fix otel-operator.yaml to avoid argocd reconcile issues

### DIFF
--- a/otel/otel-operator.yaml
+++ b/otel/otel-operator.yaml
@@ -14,54 +14,54 @@ spec:
               endpoint: 0.0.0.0:4318
       exporters:
         otlphttp/loki:
+          headers:
+            X-Scope-OrgID: nonprod.gliese667cc.onglueops.rocks
           logs_endpoint: http://loki-write-headless.glueops-core-loki:3100/otlp/v1/logs
-          headers:
-            "X-Scope-OrgID": "nonprod.gliese667cc.onglueops.rocks"
         otlphttp/trace:
-          traces_endpoint: http://grafana-tempo-distributor.glueops-core-tempo:4318/v1/traces
           headers:
-            "X-Scope-OrgID": "nonprod.gliese667cc.onglueops.rocks"
+            X-Scope-OrgID: nonprod.gliese667cc.onglueops.rocks
+          traces_endpoint: http://grafana-tempo-distributor.glueops-core-tempo:4318/v1/traces
         prometheusremotewrite:
           endpoint: http://kps-prometheus.glueops-core-kube-prometheus-stack:9090/api/v1/write
           target_info:
-            enabled: true 
+            enabled: true
       connectors:
         spanmetrics:
-          namespace: span.metrics    
+          aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
           dimensions:
-            - name: http.method
-              default: GET
+            - default: GET
+              name: http.method
             - name: http.status_code
             - name: http.target
             - name: net.peer.ip
+          dimensions_cache_size: 1000
           exemplars:
             enabled: true
-          dimensions_cache_size: 1000
-          aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"    
+          metrics_expiration: 5m
           metrics_flush_interval: 15s
-          metrics_expiration: 5m 
+          namespace: span.metrics
           resource_metrics_key_attributes:
             - service.name
             - telemetry.sdk.language
-            - telemetry.sdk.name 
-         
+            - telemetry.sdk.name
       service:
         telemetry:
           metrics:
             address: 0.0.0.0:8888
         pipelines:
-          traces:
-            receivers: [otlp]
-            processors: []
-            exporters: [otlphttp/trace, spanmetrics]
-          metrics:
-            receivers: [spanmetrics]   #otlp -> spanmetrics. # Connector 'spanmetrics' should be used as an exporter and receiver in the pipeline.
-            processors: []
-            exporters: [prometheusremotewrite]
           logs:
-            receivers: [otlp]
-            processors: []
-            exporters: [otlphttp/loki]
-          
-              
-
+            exporters:
+              - otlphttp/loki
+            receivers:
+              - otlp
+          metrics:
+            exporters:
+              - prometheusremotewrite
+            receivers:
+              - spanmetrics
+          traces:
+            exporters:
+              - otlphttp/trace
+              - spanmetrics
+            receivers:
+              - otlp


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrects YAML formatting to prevent ArgoCD reconcile issues

- Reorders and standardizes exporter configuration keys

- Updates and clarifies spanmetrics connector settings

- Reformats service pipeline sections for consistency


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>otel-operator.yaml</strong><dd><code>Standardize and fix otel-operator.yaml for ArgoCD compatibility</code></dd></summary>
<hr>

otel/otel-operator.yaml

<li>Reordered and reformatted exporter configuration keys for consistency<br> <li> Standardized YAML formatting and indentation throughout the file<br> <li> Updated spanmetrics connector settings and ordering<br> <li> Reformatted service pipeline sections to avoid ArgoCD issues


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/730/files#diff-e81dba32624b5a84ab5df0ae5f9af2d93ecc36591d04252fe50b08af4ea3cd60">+27/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>