### PR TITLE
feat: change external secret metrics port because it conflict with kps

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ This chart deploys the GlueOps Platform
 | grafana.github_other_org_names | string | `"placeholder_tenant_github_org_name"` |  |
 | host_network.cert_manager.webhook_secure_port | int | `45020` |  |
 | host_network.enabled | string | `"placeholder_enable_host_network"` |  |
+| host_network.external_secrets.webhook_metrics_port | int | `45011` |  |
 | host_network.external_secrets.webhook_port | int | `45010` |  |
 | host_network.keda.prometheus.metricServer.port | int | `45056` |  |
 | host_network.keda.prometheus.operator.port | int | `45055` |  |

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -35,9 +35,9 @@ spec:
         - name: external-secrets.webhook.port
           value: "{{ .Values.host_network.external_secrets.webhook_port }}"
         - name: external-secrets.webhook.metrics.listen.port
-          value: "8082"
+          value: "{{ .Values.host_network.external_secrets.webhook_metrics_port }}"
         - name: external-secrets.webhook.metrics.service.port
-          value: "8082"
+          value: "{{ .Values.host_network.external_secrets.webhook_metrics_port }}"
         - name: external-secrets.image.repository
           value: "{{ .Values.base_registry }}/{{ .Values.container_images.app_external_secrets.external_secrets.image.repository }}"
         - name: external-secrets.image.tag

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -34,6 +34,10 @@ spec:
           value: "{{ .Values.host_network.enabled }}"
         - name: external-secrets.webhook.port
           value: "{{ .Values.host_network.external_secrets.webhook_port }}"
+        - name: external-secrets.webhook.metrics.listen.port
+          value: "8082"
+        - name: external-secrets.webhook.metrics.service.port
+          value: "8082"
         - name: external-secrets.image.repository
           value: "{{ .Values.base_registry }}/{{ .Values.container_images.app_external_secrets.external_secrets.image.repository }}"
         - name: external-secrets.image.tag

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,7 @@ host_network:
   enabled: placeholder_enable_host_network
   external_secrets:
     webhook_port: 45010
+    webhook_metrics_port: 45011
   cert_manager:
     webhook_secure_port: 45020
   nginx_public:


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Change external secrets webhook metrics port to 8082

- Resolve port conflict with KPS service


___

### **Changes diagram**

```mermaid
flowchart LR
  A["External Secrets Webhook"] --> B["Metrics Port Changed"]
  B --> C["Port 8082 Configuration"]
  C --> D["KPS Conflict Resolved"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-external-secrets.yaml</strong><dd><code>Configure external secrets webhook metrics ports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-external-secrets.yaml

<li>Add metrics listen port configuration set to 8082<br> <li> Add metrics service port configuration set to 8082<br> <li> Configure both webhook metrics ports to avoid KPS conflict


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/742/files#diff-598d87689ac37c6848a972300a5dabece11e08c1b1b32f51360ec310cb8d7e6b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>