### PR TITLE
feat: adding CAPTAIN_DOMAIN as env variable for new cluster-information page

### DIFF
--- a/templates/application-cluster-info-page.yaml
+++ b/templates/application-cluster-info-page.yaml
@@ -49,6 +49,9 @@ spec:
             requests:
               cpu: 10m
               memory: 15Mi
+          envVariables:
+            - name: CAPTAIN_DOMAIN
+              value: {{ .Values.captain_domain }}
         
         ingress:
           enabled: true


### PR DESCRIPTION
feat: adding CAPTAIN_DOMAIN as env variable for new cluster-information page

related PR: 
https://github.com/GlueOps/cluster-information-help-page-html/pull/69