### PR TITLE
feat: migrate external-dns from bitnami to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ This chart deploys the GlueOps Platform
 | container_images.app_dex.dex.image.repository | string | `"dexidp/dex"` |  |
 | container_images.app_dex.dex.image.tag | string | `"v2.43.1@sha256:0881d3c9359b436d585b2061736ce271c100331e073be9178ef405ce5bf09557"` |  |
 | container_images.app_external_dns.external_dns.image.repository | string | `"external-dns/external-dns"` |  |
-| container_images.app_external_dns.external_dns.image.tag | string | `"v0.16.0"` |  |
+| container_images.app_external_dns.external_dns.image.tag | string | `"v0.15.1@sha256:4f3ba4c2bd28030caad05bb7b47fbf47549a46d5e8443b74f0be463550b4fc2b"` |  |
 | container_images.app_external_secrets.external_secrets.image.repository | string | `"external-secrets/external-secrets"` |  |
-| container_images.app_external_secrets.external_secrets.image.tag | string | `"v0.16.1"` |  |
+| container_images.app_external_secrets.external_secrets.image.tag | string | `"v0.16.2@sha256:bf08e22f09fe2467d62ee54b54906c065d1fcb366ff47b1dbe18186b1788d649"` |  |
 | container_images.app_fluent_operator.kubesphere.image.repository | string | `"kubesphere/fluent-operator"` |  |
 | container_images.app_fluent_operator.kubesphere.image.tag | string | `"v2.7.0@sha256:b0668c0d878bde4ab04802a7e92d0dd3bef4c1fed1b5e63cf83d49bb3c5d3947"` |  |
 | container_images.app_glueops_alerts.cluster_monitoring.image.repository | string | `"glueops/cluster-monitoring"` |  |

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ This chart deploys the GlueOps Platform
 | container_images.app_dex.dex.image.repository | string | `"dexidp/dex"` |  |
 | container_images.app_dex.dex.image.tag | string | `"v2.43.1@sha256:0881d3c9359b436d585b2061736ce271c100331e073be9178ef405ce5bf09557"` |  |
 | container_images.app_external_dns.external_dns.image.repository | string | `"external-dns/external-dns"` |  |
-| container_images.app_external_dns.external_dns.image.tag | string | `"v0.16.2@sha256:bf08e22f09fe2467d62ee54b54906c065d1fcb366ff47b1dbe18186b1788d649"` |  |
+| container_images.app_external_dns.external_dns.image.tag | string | `"v0.16.0"` |  |
 | container_images.app_external_secrets.external_secrets.image.repository | string | `"external-secrets/external-secrets"` |  |
-| container_images.app_external_secrets.external_secrets.image.tag | string | `"v0.16.2@sha256:bf08e22f09fe2467d62ee54b54906c065d1fcb366ff47b1dbe18186b1788d649"` |  |
+| container_images.app_external_secrets.external_secrets.image.tag | string | `"v0.16.1"` |  |
 | container_images.app_fluent_operator.kubesphere.image.repository | string | `"kubesphere/fluent-operator"` |  |
 | container_images.app_fluent_operator.kubesphere.image.tag | string | `"v2.7.0@sha256:b0668c0d878bde4ab04802a7e92d0dd3bef4c1fed1b5e63cf83d49bb3c5d3947"` |  |
 | container_images.app_glueops_alerts.cluster_monitoring.image.repository | string | `"glueops/cluster-monitoring"` |  |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This chart deploys the GlueOps Platform
 | container_images.app_cluster_info_page.cluster_information_help_page_html.image.tag | string | `"v0.5.0@sha256:5396f0638205a218f40d6c71edeff538b2e44dae63d3ffc34cb0b75f37b3964b"` |  |
 | container_images.app_dex.dex.image.repository | string | `"dexidp/dex"` |  |
 | container_images.app_dex.dex.image.tag | string | `"v2.43.1@sha256:0881d3c9359b436d585b2061736ce271c100331e073be9178ef405ce5bf09557"` |  |
+| container_images.app_external_dns.external_dns.image.repository | string | `"external-dns/external-dns"` |  |
+| container_images.app_external_dns.external_dns.image.tag | string | `"v0.16.2@sha256:bf08e22f09fe2467d62ee54b54906c065d1fcb366ff47b1dbe18186b1788d649"` |  |
 | container_images.app_external_secrets.external_secrets.image.repository | string | `"external-secrets/external-secrets"` |  |
 | container_images.app_external_secrets.external_secrets.image.tag | string | `"v0.16.2@sha256:bf08e22f09fe2467d62ee54b54906c065d1fcb366ff47b1dbe18186b1788d649"` |  |
 | container_images.app_fluent_operator.kubesphere.image.repository | string | `"kubesphere/fluent-operator"` |  |

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -41,8 +41,6 @@ spec:
           value: "true"
         - name: logLevel
           value: info
-        - name: serviceAccount.name
-          value: external-dns
         - name: image.repository
           value: "{{ .Values.base_registry }}/{{ .Values.container_images.app_external_dns.external_dns.image.repository }}"
         - name: image.tag

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -55,8 +55,8 @@ spec:
         sources:
           - ingress
           - service
-        managedRecordTypes: [A, CNAME, NS, TXT]
-        extraArgs: [--aws-prefer-cname,]
+        managedRecordTypes: ["A", "CNAME", "NS", "TXT"]
+        extraArgs: [--aws-prefer-cname]
         rbac:
           additionalPermissions:
             - apiGroups: [""]

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -24,40 +24,49 @@ spec:
         maxDuration: 3m0s
       limit: 5
   source:
-    repoURL: 'registry-1.docker.io/bitnamicharts'
-    chart: external-dns
-    targetRevision: 8.7.5
+    repoURL: 'https://github.com/kubernetes-sigs/external-dns'
+    path: charts/external-dns
+    targetRevision: v0.18.0
     helm:
       parameters:
-        - name: aws.credentials.secretKey
-          value: {{ .Values.externalDns.aws_secretKey }}
-        - name: aws.credentials.accessKey
-          value: {{ .Values.externalDns.aws_accessKey }}
-        - name: aws.region
-          value: {{ .Values.externalDns.aws_region }}
         - name: domainFilters[0]
           value: {{ .Values.captain_domain }}
         - name: policy
           value: sync
-        - name: global.imageRegistry
-          value: {{ .Values.base_registry }}
-        - name: global.security.allowInsecureImages
-          value: "true"
         - name: provider
           value: aws
-        - name: aws.preferCNAME
-          value: "true"
         - name: txtPrefix
           value: "extdns-"
-        - name: metrics.enabled
-          value: "true"
         - name: metrics.serviceMonitor.enabled
           value: "true"
-        - name: crd.create
-          value: "true"
-      values: |
+        - name: logLevel
+          value: info
+        - name: serviceAccount.name
+          value: external-dns
+      values: |-
         {{- toYaml .Values.glueops_node_and_tolerations | nindent 8 }}
+        env:
+          - name: AWS_DEFAULT_REGION
+            value: {{ .Values.externalDns.aws_region }}
+          - name: AWS_SECRET_ACCESS_KEY
+            value: {{ .Values.externalDns.aws_secretKey }}
+          - name: AWS_ACCESS_KEY_ID
+            value: {{ .Values.externalDns.aws_accessKey }}
         sources:
-          - crd
-          - service
           - ingress
+          - service
+        managedRecordTypes: [A, CNAME, NS, TXT]
+        extraArgs: [--aws-prefer-cname,]
+        rbac:
+          additionalPermissions:
+            - apiGroups: [""]
+              # Ensure "endpoints" is in this list of resources
+              resources: ["services", "endpoints", "pods", "nodes"]
+              verbs: ["get", "watch", "list"]
+            - apiGroups: ["extensions", "networking.k8s.io"]
+              resources: ["ingresses"]
+              verbs: ["get", "watch", "list"]
+            - apiGroups: ["discovery.k8s.io"]
+              resources: ["endpointslices"]
+              verbs: ["get", "watch", "list"]
+

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -43,6 +43,10 @@ spec:
           value: info
         - name: serviceAccount.name
           value: external-dns
+        - name: image.repository
+          value: "{{ .Values.base_registry }}/{{ .Values.container_images.app_external_dns.external_dns.image.repository }}"
+        - name: image.tag
+          value: "{{ .Values.base_registry }}/{{ .Values.container_images.app_external_dns.external_dns.image.tag }}"
       values: |-
         {{- toYaml .Values.glueops_node_and_tolerations | nindent 8 }}
         env:
@@ -55,12 +59,14 @@ spec:
         sources:
           - ingress
           - service
+          - crd
         managedRecordTypes: ["A", "CNAME", "NS", "TXT"]
-        extraArgs: [--aws-prefer-cname]
+        extraArgs: 
+          - "--aws-prefer-cname"
+          - "--aws-api-retries=3"
         rbac:
           additionalPermissions:
             - apiGroups: [""]
-              # Ensure "endpoints" is in this list of resources
               resources: ["services", "endpoints", "pods", "nodes"]
               verbs: ["get", "watch", "list"]
             - apiGroups: ["extensions", "networking.k8s.io"]

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://github.com/kubernetes-sigs/external-dns'
     path: charts/external-dns
-    targetRevision: v0.18.0
+    targetRevision: v0.16.1
     helm:
       parameters:
         - name: domainFilters[0]

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://github.com/kubernetes-sigs/external-dns'
     path: charts/external-dns
-    targetRevision: v0.16.1
+    targetRevision: external-dns-helm-chart-1.15.2
     helm:
       parameters:
         - name: domainFilters[0]
@@ -46,7 +46,7 @@ spec:
         - name: image.repository
           value: "{{ .Values.base_registry }}/{{ .Values.container_images.app_external_dns.external_dns.image.repository }}"
         - name: image.tag
-          value: "{{ .Values.base_registry }}/{{ .Values.container_images.app_external_dns.external_dns.image.tag }}"
+          value: "{{ .Values.container_images.app_external_dns.external_dns.image.tag }}"
       values: |-
         {{- toYaml .Values.glueops_node_and_tolerations | nindent 8 }}
         env:

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -60,19 +60,8 @@ spec:
           - ingress
           - service
           - crd
-        managedRecordTypes: ["A", "CNAME", "NS", "TXT"]
         extraArgs: 
           - "--aws-prefer-cname"
           - "--aws-api-retries=3"
-        rbac:
-          additionalPermissions:
-            - apiGroups: [""]
-              resources: ["services", "endpoints", "pods", "nodes"]
-              verbs: ["get", "watch", "list"]
-            - apiGroups: ["extensions", "networking.k8s.io"]
-              resources: ["ingresses"]
-              verbs: ["get", "watch", "list"]
-            - apiGroups: ["discovery.k8s.io"]
-              resources: ["endpointslices"]
-              verbs: ["get", "watch", "list"]
+        
 

--- a/values.yaml
+++ b/values.yaml
@@ -247,12 +247,13 @@ container_images:
     external_secrets:
       image:
         repository: external-secrets/external-secrets
-        tag: v0.16.1
+        tag: v0.16.2@sha256:bf08e22f09fe2467d62ee54b54906c065d1fcb366ff47b1dbe18186b1788d649
   app_external_dns:
     external_dns:
       image:
         repository: external-dns/external-dns
-        tag: v0.16.0
+        tag: v0.15.1@sha256:4f3ba4c2bd28030caad05bb7b47fbf47549a46d5e8443b74f0be463550b4fc2b
+
   app_backup_and_exports:
     vault_backup_validator:
       image:

--- a/values.yaml
+++ b/values.yaml
@@ -247,12 +247,12 @@ container_images:
     external_secrets:
       image:
         repository: external-secrets/external-secrets
-        tag: v0.16.2@sha256:bf08e22f09fe2467d62ee54b54906c065d1fcb366ff47b1dbe18186b1788d649
+        tag: v0.16.1
   app_external_dns:
     external_dns:
       image:
         repository: external-dns/external-dns
-        tag: v0.16.2@sha256:bf08e22f09fe2467d62ee54b54906c065d1fcb366ff47b1dbe18186b1788d649
+        tag: v0.16.0
   app_backup_and_exports:
     vault_backup_validator:
       image:

--- a/values.yaml
+++ b/values.yaml
@@ -248,6 +248,11 @@ container_images:
       image:
         repository: external-secrets/external-secrets
         tag: v0.16.2@sha256:bf08e22f09fe2467d62ee54b54906c065d1fcb366ff47b1dbe18186b1788d649
+  app_external_dns:
+    external_dns:
+      image:
+        repository: external-dns/external-dns
+        tag: v0.16.2@sha256:bf08e22f09fe2467d62ee54b54906c065d1fcb366ff47b1dbe18186b1788d649
   app_backup_and_exports:
     vault_backup_validator:
       image:


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Migrate external-dns from Bitnami Helm chart to official GitHub repository

- Update chart source from registry to Git repository with path-based deployment

- Restructure AWS credentials configuration from Helm parameters to environment variables

- Enhance RBAC permissions for additional Kubernetes resources access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bitnami Registry Chart"] -- "migrate to" --> B["GitHub Repository Chart"]
  B --> C["Environment Variables Config"]
  B --> D["Enhanced RBAC Permissions"]
  C --> E["AWS Credentials Setup"]
  D --> F["Extended Resource Access"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-external-dns.yaml</strong><dd><code>Migrate external-dns chart source and configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-external-dns.yaml

<ul><li>Changed chart source from Bitnami registry to GitHub repository<br> <li> Moved AWS credentials from Helm parameters to environment variables<br> <li> Added enhanced RBAC permissions for endpoints and endpointslices<br> <li> Updated managed record types and extra arguments configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/769/files#diff-77f505fbaa80b2ae0f9386fda952a8ed063fc00d35b729f2f24a66b1070900f6">+31/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

