### PR TITLE
fix: loki canary is using docker.io and not one of our mirrors

### DIFF
--- a/templates/application-loki.yaml
+++ b/templates/application-loki.yaml
@@ -80,6 +80,8 @@ spec:
             grafanaAgent:
               installOperator: false
           lokiCanary:
+            image:
+              registry: '{{ .Values.base_registry }}'
             tolerations:
               {{- toYaml .Values.daemonset_tolerations | nindent 14 }}
         write:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Configure Loki canary to use custom registry instead of docker.io


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["docker.io registry"] -- "replace with" --> B["custom registry mirror"]
  B --> C["Loki canary image"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-loki.yaml</strong><dd><code>Configure custom registry for Loki canary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-loki.yaml

<ul><li>Add image registry configuration for Loki canary<br> <li> Set registry to use <code>{{ .Values.base_registry }}</code> template value</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/770/files#diff-35d196c1e2f73b4c5bae7a929e46ae128a109d728fe4b5fa588e5ebd1853134b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

