### PR TITLE
fix: the glueops-platform control plane nginx doesn't need more than 2 for HA

### DIFF
--- a/templates/glueops-platform-ingress/application-nginx-glueops-platform-oauth2.yaml
+++ b/templates/glueops-platform-ingress/application-nginx-glueops-platform-oauth2.yaml
@@ -48,7 +48,7 @@ spec:
             digest: ""
           admissionWebhooks:
             enabled: false
-          replicaCount: {{ .Values.nginx.controller_replica_count }}
+          replicaCount: 2
           maxUnavailable: 1
           config:
             use-forwarded-headers: true


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Hardcode nginx controller replica count to 2

- Remove configurable replica count for control plane


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Configurable Replica Count"] --> B["Fixed Replica Count = 2"]
  B --> C["High Availability Maintained"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-nginx-glueops-platform-oauth2.yaml</strong><dd><code>Hardcode nginx replica count to 2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/glueops-platform-ingress/application-nginx-glueops-platform-oauth2.yaml

<ul><li>Replace variable <code>{{ .Values.nginx.controller_replica_count }}</code> with <br>hardcoded value <code>2</code><br> <li> Remove trailing whitespace at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/793/files#diff-0a976ab39a0901334030ec18101d537fe529b2657e1a912cc5836e4a3e2eccfe">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

