### PR TITLE
feat: migrating to public-mirror.gpkg.io for better control during registry outages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This chart deploys the GlueOps Platform
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| base_registry | string | `"ghcr.io/glueops/mirror"` |  |
+| base_registry | string | `"public-mirror.gpkg.io/glueops/mirror"` |  |
 | captain_domain | string | `"placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain"` | The Route53 subdomain for the services on your cluster. It will be used as the suffix url for argocd, grafana, vault, and any other services that come out of the box in the glueops platform. Note: you need to create this before using this repo as this repo does not provision DNS Zones for you. This is the domain you created through: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | captain_repo.private_b64enc_deploy_key | string | `"placeholder_captain_repo_b64enc_private_deploy_key"` | This is a read only deploy key that will be used to read the captain repo. Part of output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | captain_repo.ssh_clone_url | string | `"placeholder_captain_repo_ssh_clone_url"` | This is the github url of the captain repo https://github.com/glueops/development-captains/tenant . Part of output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |

--- a/values.yaml
+++ b/values.yaml
@@ -241,7 +241,7 @@ tls_cert_restore:
   backup_prefix: placeholder_tls_cert_backup_s3_key_prefix
   exclude_namespaces: placeholder_tls_cert_restore_exclude_namespaces
 
-base_registry: ghcr.io/glueops/mirror
+base_registry: public-mirror.gpkg.io/glueops/mirror
 container_images:
   app_external_secrets:
     external_secrets:


### PR DESCRIPTION
Recently there was a routing issue between hetzner and ghcr.io (github packages) This caused all images to pull down very slowly. What usually took seconds ended up taking minutes. In some cases 20-40mins. This has happened on a few cases in particular with the codespaces repository when running setup.glueops.dev or when just manually pulling ghcr.io packages that we use for the platform.

Currently `public-mirror.pgkg.io` is still pointed at ghcr.io but if that goes down we can route to quay.io and if that goes down we can migrate back or setup a proxy. When migrating from ghcr.io -> quay.io -> anything, all of it is handle in the deployment of https://github.com/GlueOps/registry-facade . So we just update the deployment and then public-mirror.gpkg.io will route to the failover/new registry provider.

I plan to bring it up in the architecture meeting this week