### PR TITLE
feat: add change for ingress to adopt lb in worker nodes

### DIFF
--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -105,7 +105,7 @@ spec:
             hostNetwork: {{ .Values.host_network.enabled }}
             {{- if .Values.kube_etcd.enabled }}
             secrets:
-              - etcd-client
+              - etcd-client-certs
             {{- end }}
         grafana:
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -49,6 +49,12 @@ spec:
             enabled: false
           replicaCount: {{ .Values.nginx.controller_replica_count }}
           maxUnavailable: 1
+          hostPort:
+            enabled: true
+          kind: DaemonSet
+          hostNetwork: true
+          podAnnotations:
+            external-dns.alpha.kubernetes.io/endpoints-type: HostIP
           config:
             use-forwarded-headers: true
             ssl-reject-handshake: true
@@ -99,6 +105,7 @@ spec:
           extraArgs:
             default-ssl-certificate: glueops-core-cert-manager/{{ .Values.certManager.name_of_default_certificate }}
           service:
+            enabled: false
             annotations:
               service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
               external-dns.alpha.kubernetes.io/hostname: ingress.{{ .Values.captain_domain }}
@@ -113,24 +120,12 @@ spec:
               https: {{ .Values.node_ports.nginx.ports.https }}
             {{- end }}
 
-            externalTrafficPolicy: "Local"
           # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2366
           # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2366#issuecomment-1788923154
           updateStrategy:
             rollingUpdate:
               maxSurge: 1
               maxUnavailable: 0
-          # Add a pause to make time for the pod to be registered in the AWS NLB target group before proceeding with the next
-          # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1834#issuecomment-781530724
-          # https://alexklibisz.com/2021/07/20/speed-limits-for-rolling-restarts-in-kubernetes#round-3-set-minreadyseconds-maxunavailable-to-0-and-maxsurge-to-1
-          minReadySeconds: 180
-          # Add sleep on preStop to allow for graceful shutdown with AWS NLB
-          # https://github.com/kubernetes/ingress-nginx/issues/6928
-          # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2366#issuecomment-1118312709
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "sleep 240; /wait-shutdown"]
           metrics:
             enabled: true
             serviceMonitor:
@@ -143,23 +138,13 @@ spec:
             enabled: true
             default: false
             controllerValue: "k8s.io/public-ingress-nginx"
-          affinity: 
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
-                podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                    - key: app.kubernetes.io/name
-                      operator: In
-                      values:
-                      - ingress-nginx
-                    - key: app.kubernetes.io/instance
-                      operator: In
-                      values:
-                      - public-ingress-nginx
-                    - key: app.kubernetes.io/component
-                      operator: In
-                      values:
-                      - controller
-                  topologyKey: kubernetes.io/hostname
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: public-ingress
+                    operator: In
+                    values:
+                    - "true"
+            

--- a/templates/glueops-platform-ingress/application-nginx-glueops-platform-oauth2.yaml
+++ b/templates/glueops-platform-ingress/application-nginx-glueops-platform-oauth2.yaml
@@ -50,6 +50,12 @@ spec:
             enabled: false
           replicaCount: {{ .Values.nginx.controller_replica_count }}
           maxUnavailable: 1
+          hostPort:
+            enabled: true
+          kind: DaemonSet
+          hostNetwork: true
+          podAnnotations:
+            external-dns.alpha.kubernetes.io/endpoints-type: HostIP
           config:
             use-forwarded-headers: true
             ssl-reject-handshake: true
@@ -100,38 +106,24 @@ spec:
           extraArgs:
             default-ssl-certificate: glueops-core-cert-manager/{{ .Values.certManager.name_of_default_certificate }}
           service:
+            enabled: false
             annotations:
               service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
               external-dns.alpha.kubernetes.io/hostname: glueops-platform-ingress.{{ .Values.captain_domain }}
               {{- if .Values.enable_chisel_proxy_protocol }}
               chisel-operator.io/proxy-protocol: "true"
               {{- end }}
-
-            type: {{- if .Values.node_ports.enabled }} "NodePort" {{- else }} "LoadBalancer" {{- end }}
             {{- if .Values.node_ports.enabled }}
             nodePorts:
               http: {{ .Values.node_ports.oauth2_proxy.ports.http }}
               https: {{ .Values.node_ports.oauth2_proxy.ports.https }}
             {{- end }}
-
-            externalTrafficPolicy: "Local"
           # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2366
           # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2366#issuecomment-1788923154
           updateStrategy:
             rollingUpdate:
               maxSurge: 1
               maxUnavailable: 0
-          # Add a pause to make time for the pod to be registered in the AWS NLB target group before proceeding with the next
-          # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1834#issuecomment-781530724
-          # https://alexklibisz.com/2021/07/20/speed-limits-for-rolling-restarts-in-kubernetes#round-3-set-minreadyseconds-maxunavailable-to-0-and-maxsurge-to-1
-          minReadySeconds: 180
-          # Add sleep on preStop to allow for graceful shutdown with AWS NLB
-          # https://github.com/kubernetes/ingress-nginx/issues/6928
-          # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2366#issuecomment-1118312709
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "sleep 240; /wait-shutdown"]
           metrics:
             enabled: true
             serviceMonitor:
@@ -144,7 +136,15 @@ spec:
             enabled: true
             default: false
             controllerValue: "k8s.io/glueops-platform-ingress-nginx"
-          affinity: 
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: glueops-platform-ingress
+                    operator: In
+                    values:
+                    - "true"
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
               - weight: 100


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Convert NGINX ingress controllers to DaemonSet with hostNetwork

- Enable hostPort and HostIP endpoints for external-dns

- Replace LoadBalancer service with node affinity targeting

- Remove AWS NLB specific configurations and lifecycle hooks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LoadBalancer Service"] --> B["DaemonSet with hostNetwork"]
  C["Pod Anti-Affinity"] --> D["Node Affinity"]
  E["AWS NLB Config"] --> F["HostIP Endpoints"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-kube-prometheus-stack.yaml</strong><dd><code>Fix etcd client certificate secret reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-kube-prometheus-stack.yaml

<ul><li>Update etcd client secret name from <code>etcd-client</code> to <code>etcd-client-certs</code></ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/824/files#diff-87a59bc30480a9bd9c023721224637a3e2c117ea1b0a2843f98188bc105f3ce3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-nginx-public.yaml</strong><dd><code>Convert public NGINX to DaemonSet with node affinity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-nginx-public.yaml

<ul><li>Convert controller to DaemonSet with hostNetwork and hostPort enabled<br> <li> Disable LoadBalancer service and remove AWS NLB configurations<br> <li> Replace pod anti-affinity with node affinity for <code>public-ingress</code> nodes<br> <li> Remove lifecycle hooks and minReadySeconds for AWS NLB compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/824/files#diff-b8951700ccd41112fa2d2a037fe78e1b4f6e49da48fc3592c0605afdad3c15cc">+17/-32</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>application-nginx-glueops-platform-oauth2.yaml</strong><dd><code>Convert platform NGINX to DaemonSet with node affinity</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/glueops-platform-ingress/application-nginx-glueops-platform-oauth2.yaml

<ul><li>Convert controller to DaemonSet with hostNetwork and hostPort enabled<br> <li> Disable LoadBalancer service and remove AWS NLB configurations<br> <li> Add node affinity for <code>glueops-platform-ingress</code> nodes alongside <br>existing pod anti-affinity<br> <li> Remove lifecycle hooks and minReadySeconds for AWS NLB compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/824/files#diff-0a976ab39a0901334030ec18101d537fe529b2657e1a912cc5836e4a3e2eccfe">+16/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

