### PR TITLE
fix: set proxy url internal svc.cluster.local endpoint

### DIFF
--- a/templates/application-cluster-info-page.yaml
+++ b/templates/application-cluster-info-page.yaml
@@ -57,8 +57,8 @@ spec:
           enabled: true
           ingressClassName: glueops-platform
           annotations:
-            nginx.ingress.kubernetes.io/auth-signin: "http://oauth2.{{ .Values.captain_domain }}/oauth2/start?rd=https://$host$request_uri"
-            nginx.ingress.kubernetes.io/auth-url: "http://oauth2.{{ .Values.captain_domain }}/oauth2/auth"
+            nginx.ingress.kubernetes.io/auth-signin: "http://oauth2-proxy.glueops-core-oauth2-proxy.svc.cluster.local/oauth2/start?rd=https://$host$request_uri"
+            nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.glueops-core-oauth2-proxy.svc.cluster.local/oauth2/auth"
             nginx.ingress.kubernetes.io/auth-response-headers: "authorization, x-auth-request-user, x-auth-request-email, x_auth_request_access_token"
           entries:
             - name: glueops-platform

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -135,8 +135,8 @@ spec:
             enabled: true
             ingressClassName: glueops-platform
             annotations:
-              nginx.ingress.kubernetes.io/auth-signin: "http://oauth2.{{ .Values.captain_domain }}/oauth2/start?rd=https://$host$request_uri"
-              nginx.ingress.kubernetes.io/auth-url: "http://oauth2.{{ .Values.captain_domain }}/oauth2/auth"
+              nginx.ingress.kubernetes.io/auth-signin: "http://oauth2-proxy.glueops-core-oauth2-proxy.svc.cluster.local/oauth2/start?rd=https://$host$request_uri"
+              nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.glueops-core-oauth2-proxy.svc.cluster.local/oauth2/auth"
               nginx.ingress.kubernetes.io/auth-response-headers: "authorization, x-auth-request-user, x-auth-request-email, x_auth_request_access_token"
             hosts: ['grafana.{{ .Values.captain_domain }}']
             path: "/"

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -53,8 +53,8 @@ spec:
               ingressClassName: glueops-platform
               annotations: 
                 cert-manager.io/cluster-issuer: letsencrypt
-                nginx.ingress.kubernetes.io/auth-signin: "http://oauth2.{{ .Values.captain_domain }}/oauth2/start?rd=https://$host$request_uri"
-                nginx.ingress.kubernetes.io/auth-url: "http://oauth2.{{ .Values.captain_domain }}/oauth2/auth"
+                nginx.ingress.kubernetes.io/auth-signin: "http://oauth2-proxy.glueops-core-oauth2-proxy.svc.cluster.local/oauth2/start?rd=https://$host$request_uri"
+                nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.glueops-core-oauth2-proxy.svc.cluster.local/oauth2/auth"
                 nginx.ingress.kubernetes.io/auth-response-headers: "authorization, x-auth-request-user, x-auth-request-email, x_auth_request_access_token"
                 nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
               enabled: true


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace external domain URLs with internal cluster service endpoints

- Update OAuth2 proxy authentication URLs to use `svc.cluster.local`

- Fix ingress annotations across cluster-info, Grafana, and Vault applications


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["External Domain URLs"] -- "Replace with" --> B["Internal Cluster Service"]
  B --> C["oauth2-proxy.glueops-core-oauth2-proxy.svc.cluster.local"]
  C --> D["Updated Ingress Annotations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application-cluster-info-page.yaml</strong><dd><code>Update cluster-info OAuth2 proxy URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-cluster-info-page.yaml

<ul><li>Replace OAuth2 proxy URLs with internal cluster service endpoints<br> <li> Update <code>auth-signin</code> and <code>auth-url</code> annotations to use <code>svc.cluster.local</code></ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/956/files#diff-4a288ee2dd2d1485fadbc05092c140f3df4ae6a1bb7c8152660147a540e86686">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>application-kube-prometheus-stack.yaml</strong><dd><code>Update Grafana OAuth2 proxy URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-kube-prometheus-stack.yaml

<ul><li>Replace OAuth2 proxy URLs with internal cluster service endpoints<br> <li> Update Grafana ingress annotations to use <code>svc.cluster.local</code></ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/956/files#diff-87a59bc30480a9bd9c023721224637a3e2c117ea1b0a2843f98188bc105f3ce3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>application-vault.yaml</strong><dd><code>Update Vault OAuth2 proxy URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/application-vault.yaml

<ul><li>Replace OAuth2 proxy URLs with internal cluster service endpoints<br> <li> Update Vault ingress annotations to use <code>svc.cluster.local</code></ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-platform/pull/956/files#diff-cb4686972e88e1c744b094bfe3d13b6e64bf2a5b0a9bd9a69a7f187f4f387642">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

