### PR TITLE
refactor:  

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@ This chart deploys the GlueOps Platform
 | certManager.aws_accessKey | string | `"placeholder_certmanager_aws_access_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | certManager.aws_region | string | `"placeholder_aws_region"` | Should be the same `primary_region` you used in: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | certManager.aws_secretKey | string | `"placeholder_certmanager_aws_secret_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
+| chart_versions.cert_manager | string | `"v1.18.2"` |  |
+| chart_versions.cert_reflector | string | `"10.0.8"` |  |
+| chart_versions.descheduler | string | `"v0.33.0"` |  |
+| chart_versions.dex | string | `"0.24.0"` |  |
+| chart_versions.external_dns | string | `"external-dns-helm-chart-1.20.0"` |  |
+| chart_versions.external_secrets | string | `"0.19.2"` |  |
+| chart_versions.fluent_operator | string | `"v2.7.0"` |  |
+| chart_versions.glueops_grafana_dashboards | string | `"v0.12.1"` |  |
+| chart_versions.keda | string | `"2.17.2"` |  |
+| chart_versions.kube_prometheus_stack | string | `"59.1.0"` |  |
+| chart_versions.kube_prometheus_stack_crds | string | `"kube-prometheus-stack-59.1.0"` |  |
+| chart_versions.loki | string | `"5.48.0"` |  |
+| chart_versions.metacontroller | string | `"v4.12.5"` |  |
+| chart_versions.nginx | string | `"4.13.3"` |  |
+| chart_versions.oauth2_proxy | string | `"9.0.0"` |  |
+| chart_versions.openbao | string | `"0.19.3"` |  |
+| chart_versions.project_template | string | `"0.9.0"` |  |
+| chart_versions.project_template_vault_init | string | `"0.8.1"` |  |
+| chart_versions.promtail | string | `"6.15.5"` |  |
+| chart_versions.traefik | string | `"39.0.0"` |  |
+| chart_versions.traefik_crds | string | `"v39.0.0"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.repository | string | `"glueops/backup-tools"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.tag | string | `"v2.7.0@sha256:64e194438f3d056b4a658978be30cd06dce2d37e8df65db611b65aad0e7c3231"` |  |
@@ -70,6 +91,9 @@ This chart deploys the GlueOps Platform
 | container_images.app_kube_prometheus_stack.grafana.image.registry | string | `"dockerhub.repo.gpkg.io"` |  |
 | container_images.app_kube_prometheus_stack.grafana.image.repository | string | `"grafana/grafana"` |  |
 | container_images.app_kube_prometheus_stack.grafana.image.tag | string | `"10.4.19-security-01@sha256:5584505cb75be8cb14c19d7473a87e2675c68b34b546bc1923ef74300c337111"` |  |
+| container_images.app_kubectl.kubectl.image.registry | string | `"dockerhub.repo.gpkg.io"` |  |
+| container_images.app_kubectl.kubectl.image.repository | string | `"bitnami/kubectl"` |  |
+| container_images.app_kubectl.kubectl.image.tag | string | `"1.33.1"` |  |
 | container_images.app_loki.loki.image.registry | string | `"dockerhub.repo.gpkg.io"` |  |
 | container_images.app_loki.loki.image.repository | string | `"grafana/loki"` |  |
 | container_images.app_loki.loki.image.tag | string | `"2.9.10@sha256:35b02acc67654ddc38273e519b4f26f3967a907b9db5489af300c21f37ee1ae7"` |  |

--- a/templates/application-argocd-servicemonitors.yaml
+++ b/templates/application-argocd-servicemonitors.yaml
@@ -19,14 +19,14 @@ spec:
       selfHeal: true
     retry:
       backoff:
-        duration: 60s
+        duration: 10s
         maxDuration: 3m0s
         factor: 2
-      limit: 10
+      limit: 5
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.9.0
+    targetRevision: {{ .Values.chart_versions.project_template }}
     helm:
       values: |
         appName: '{{ .Release.Name }}'

--- a/templates/application-backups-and-exports.yaml
+++ b/templates/application-backups-and-exports.yaml
@@ -17,14 +17,14 @@ spec:
       selfHeal: true
     retry:
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
         maxDuration: 3m0s
-      limit: 2
+      limit: 5
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.9.0
+    targetRevision: {{ .Values.chart_versions.project_template }}
     helm:
       values: |+
         appName: "glueops-backup-and-exports"

--- a/templates/application-ccm-gluekube.yaml
+++ b/templates/application-ccm-gluekube.yaml
@@ -18,14 +18,14 @@ spec:
       selfHeal: true
     retry:
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
         maxDuration: 3m0s
-      limit: 2
+      limit: 5
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.9.0
+    targetRevision: {{ .Values.chart_versions.project_template }}
     helm:
       values: |+
         appName: "glueops-core-glueops-ccm-gluekube"

--- a/templates/application-cert-manager.yaml
+++ b/templates/application-cert-manager.yaml
@@ -22,7 +22,7 @@ spec:
         duration: 10s
         factor: 2
         maxDuration: 3m0s
-      limit: 10
+      limit: 5
   ignoreDifferences:
     - group: apps
       kind: Job
@@ -32,7 +32,7 @@ spec:
   source:
     repoURL: quay.io/jetstack/charts
     chart: cert-manager
-    targetRevision: v1.18.2
+    targetRevision: {{ .Values.chart_versions.cert_manager }}
     helm:
       parameters:
         - name: crds.enabled

--- a/templates/application-cert-reflector.yaml
+++ b/templates/application-cert-reflector.yaml
@@ -23,13 +23,13 @@ spec:
         duration: 10s
         factor: 2
         maxDuration: 3m0s
-      limit: 10
+      limit: 5
   source:
     repoURL: https://emberstack.github.io/helm-charts
     chart: reflector
     # pick a specific chart version you want to pin.
     # If you want to track latest, you can set this to something like "10.x.x" only if your ArgoCD/Helm setup supports semver ranges.
-    targetRevision: 10.0.8
+    targetRevision: {{ .Values.chart_versions.cert_reflector }}
     helm:
       releaseName: reflector
       values: |-

--- a/templates/application-cluster-info-page.yaml
+++ b/templates/application-cluster-info-page.yaml
@@ -17,14 +17,14 @@ spec:
       selfHeal: true
     retry:
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
         maxDuration: 3m0s
-      limit: 2
+      limit: 5
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.9.0
+    targetRevision: {{ .Values.chart_versions.project_template }}
     helm:
       values: |+
         appName: "glueops-cluster-info-page"

--- a/templates/application-descheduler.yaml
+++ b/templates/application-descheduler.yaml
@@ -22,7 +22,7 @@ spec:
   source:
     repoURL: 'https://github.com/kubernetes-sigs/descheduler.git'
     path: charts/descheduler
-    targetRevision: v0.33.0
+    targetRevision: {{ .Values.chart_versions.descheduler }}
     helm:
       parameters:
         - name: kind

--- a/templates/application-dex.yaml
+++ b/templates/application-dex.yaml
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: https://charts.dexidp.io
     chart: dex
-    targetRevision: 0.24.0
+    targetRevision: {{ .Values.chart_versions.dex }}
     helm:
       values: |
         {{- toYaml .Values.glueops_node_and_tolerations | nindent 8 }}

--- a/templates/application-external-dns.yaml
+++ b/templates/application-external-dns.yaml
@@ -13,7 +13,7 @@ spec:
   project: glueops-core
   syncPolicy:
     syncOptions:
-      - CreateNamespace=true  
+      - CreateNamespace=true
     automated:
       prune: true
       selfHeal: true
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://github.com/kubernetes-sigs/external-dns'
     path: charts/external-dns
-    targetRevision: external-dns-helm-chart-1.20.0
+    targetRevision: {{ .Values.chart_versions.external_dns }}
     helm:
       parameters:
         - name: domainFilters[0]

--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -33,7 +33,7 @@ spec:
   source:
     repoURL: ghcr.io/external-secrets/charts
     chart: external-secrets
-    targetRevision: 0.19.2
+    targetRevision: {{ .Values.chart_versions.external_secrets }}
     helm:
       parameters:
         - name: webhook.hostNetwork

--- a/templates/application-fluent-operator.yaml
+++ b/templates/application-fluent-operator.yaml
@@ -13,7 +13,7 @@ spec:
   project: glueops-core
   syncPolicy:
     syncOptions:
-      - CreateNamespace=true  
+      - CreateNamespace=true
     automated:
       prune: true
       selfHeal: true
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://fluent.github.io/helm-charts'
     chart: fluent-operator
-    targetRevision: v2.7.0
+    targetRevision: {{ .Values.chart_versions.fluent_operator }}
     helm:
       values: |-
           operator:

--- a/templates/application-glueops-alerts.yaml
+++ b/templates/application-glueops-alerts.yaml
@@ -13,7 +13,7 @@ spec:
   project: glueops-core
   syncPolicy:
     syncOptions:
-      - CreateNamespace=true  
+      - CreateNamespace=true
       - Replace=true
     automated:
       prune: true
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.9.0
+    targetRevision: {{ .Values.chart_versions.project_template }}
     helm:
       values: |
         appName: 'glueops-core-alerts'

--- a/templates/application-glueops-grafana-dashboards.yaml
+++ b/templates/application-glueops-grafana-dashboards.yaml
@@ -26,4 +26,4 @@ spec:
   source:
     repoURL: 'https://github.com/GlueOps/platform-helm-chart-grafana-dashboards'
     path: .
-    targetRevision: v0.12.1
+    targetRevision: {{ .Values.chart_versions.glueops_grafana_dashboards }}

--- a/templates/application-go-healthz.yaml
+++ b/templates/application-go-healthz.yaml
@@ -18,14 +18,14 @@ spec:
       selfHeal: true
     retry:
       backoff:
-        duration: 5s
+        duration: 10s
         maxDuration: 3m0s
         factor: 2
-      limit: 2
+      limit: 5
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.9.0
+    targetRevision: {{ .Values.chart_versions.project_template }}
     helm:
       values: |
         appName: 'go-healthz'

--- a/templates/application-keda.yaml
+++ b/templates/application-keda.yaml
@@ -16,7 +16,7 @@ spec:
   project: glueops-core
   syncPolicy:
     syncOptions:
-      - CreateNamespace=true  
+      - CreateNamespace=true
       - Replace=true
     automated:
       prune: true
@@ -29,7 +29,7 @@ spec:
       limit: 5
   source:
     repoURL: 'https://kedacore.github.io/charts'
-    targetRevision: 2.17.2
+    targetRevision: {{ .Values.chart_versions.keda }}
     chart: keda
     helm:
       values: |-
@@ -45,16 +45,14 @@ spec:
                     memory: 1000Mi
         prometheus:
             metricServer:
-            enabled: true
-        prometheus:
+                enabled: true
+                port: {{ .Values.host_network.keda.prometheus.metricServer.port }}
             webhooks:
                 enabled: true
                 port: {{ .Values.host_network.keda.prometheus.webhooks.port }}
             operator:
                 enabled: true
                 port: {{ .Values.host_network.keda.prometheus.operator.port }}
-            metricServer:
-                port: {{ .Values.host_network.keda.prometheus.metricServer.port }}
         service:
             portHttps:  {{ .Values.host_network.keda.service.portHttps }}
             portHttpsTarget: {{ .Values.host_network.keda.service.portHttpsTarget }}

--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/charts/crds/crds
-    targetRevision: kube-prometheus-stack-59.1.0
+    targetRevision: {{ .Values.chart_versions.kube_prometheus_stack_crds }}
     directory:
       recurse: true
     

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://prometheus-community.github.io/helm-charts'
     chart: kube-prometheus-stack
-    targetRevision: 59.1.0
+    targetRevision: {{ .Values.chart_versions.kube_prometheus_stack }}
     helm:
       skipCrds: true
       values: |-

--- a/templates/application-loki-alert-group-controller.yaml
+++ b/templates/application-loki-alert-group-controller.yaml
@@ -19,14 +19,14 @@ spec:
       selfHeal: true
     retry:
       backoff:
-        duration: 5s
+        duration: 10s
         maxDuration: 3m0s
         factor: 2
-      limit: 2
+      limit: 5
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.9.0
+    targetRevision: {{ .Values.chart_versions.project_template }}
     helm:
       values: |
         appName: '{{ .Release.Name }}'

--- a/templates/application-loki.yaml
+++ b/templates/application-loki.yaml
@@ -13,7 +13,7 @@ spec:
   project: glueops-core
   syncPolicy:
     syncOptions:
-      - CreateNamespace=true  
+      - CreateNamespace=true
     automated:
       prune: true
       selfHeal: true
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://grafana.github.io/helm-charts'
     chart: loki
-    targetRevision: 5.48.0
+    targetRevision: {{ .Values.chart_versions.loki }}
     helm:
       parameters:
         - name: loki.image.registry

--- a/templates/application-metacontroller.yaml
+++ b/templates/application-metacontroller.yaml
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: https://github.com/metacontroller/metacontroller.git
     path: deploy/helm/metacontroller
-    targetRevision: v4.12.5
+    targetRevision: {{ .Values.chart_versions.metacontroller }}
     helm:
       parameters:
         - name: replicas

--- a/templates/application-network-exporter.yaml
+++ b/templates/application-network-exporter.yaml
@@ -18,14 +18,14 @@ spec:
       selfHeal: true
     retry:
       backoff:
-        duration: 5s
+        duration: 10s
         maxDuration: 3m0s
         factor: 2
-      limit: 2
+      limit: 5
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.9.0
+    targetRevision: {{ .Values.chart_versions.project_template }}
     helm:
       values: |
         appName: 'glueops-network-exporter'
@@ -36,6 +36,8 @@ spec:
             kind: DaemonSet
             metadata:
               labels:
+                app.kubernetes.io/instance: glueops-network-exporter
+                app.kubernetes.io/name: glueops-network-exporter
               name: glueops-network-exporter
               namespace: glueops-core-network-exporter
             spec:

--- a/templates/application-nginx-public.yaml
+++ b/templates/application-nginx-public.yaml
@@ -14,7 +14,7 @@ spec:
   project: glueops-core
   syncPolicy:
     syncOptions:
-      - CreateNamespace=true  
+      - CreateNamespace=true
     automated:
       prune: true
       selfHeal: true
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: 'https://kubernetes.github.io/ingress-nginx'
     chart: ingress-nginx
-    targetRevision: 4.13.3
+    targetRevision: {{ .Values.chart_versions.nginx }}
     helm:
       values: |-
         defaultBackend:

--- a/templates/application-promtail.yaml
+++ b/templates/application-promtail.yaml
@@ -13,7 +13,7 @@ spec:
   project: glueops-core
   syncPolicy:
     syncOptions:
-      - CreateNamespace=true  
+      - CreateNamespace=true
     automated:
       prune: true
       selfHeal: true
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://grafana.github.io/helm-charts'
     chart: promtail
-    targetRevision: 6.15.5
+    targetRevision: {{ .Values.chart_versions.promtail }}
     helm:
       parameters:
         - name: config.clients[0].url

--- a/templates/application-traefik-internal.yaml
+++ b/templates/application-traefik-internal.yaml
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: https://traefik.github.io/charts
     chart: traefik
-    targetRevision: 39.0.0
+    targetRevision: {{ .Values.chart_versions.traefik }}
     helm:
       skipCrds: true
       values: |-

--- a/templates/application-traefik-platform.yaml
+++ b/templates/application-traefik-platform.yaml
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: https://traefik.github.io/charts
     chart: traefik
-    targetRevision: 39.0.0
+    targetRevision: {{ .Values.chart_versions.traefik }}
     helm:
       skipCrds: true
       values: |-

--- a/templates/application-traefik-public.yaml
+++ b/templates/application-traefik-public.yaml
@@ -27,7 +27,7 @@ spec:
   source:
     repoURL: https://traefik.github.io/charts
     chart: traefik
-    targetRevision: 39.0.0
+    targetRevision: {{ .Values.chart_versions.traefik }}
     helm:
       # CRITICAL: CRDs are installed by the CRD-only app
       skipCrds: true

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -32,7 +32,7 @@ spec:
   source:
     repoURL: ghcr.io/openbao/charts
     chart: openbao
-    targetRevision: 0.19.3
+    targetRevision: {{ .Values.chart_versions.openbao }}
     helm:
       values: |-
         # OpenBao Helm Chart Value Overrides (cutover from Vault)
@@ -249,7 +249,7 @@ spec:
             source:
               repoURL: https://helm.gpkg.io/project-template
               chart: app
-              targetRevision: 0.8.1
+              targetRevision: {{ .Values.chart_versions.project_template_vault_init }}
               helm:
                 values: |
                   appName: 'vault-init-controller'

--- a/templates/glueops-platform-ingress/application-oauth2.yaml
+++ b/templates/glueops-platform-ingress/application-oauth2.yaml
@@ -13,7 +13,7 @@ spec:
   project: glueops-core
   syncPolicy:
     syncOptions:
-      - CreateNamespace=true  
+      - CreateNamespace=true
     automated:
       prune: true
       selfHeal: true
@@ -26,7 +26,7 @@ spec:
   source:
     repoURL: 'https://oauth2-proxy.github.io/manifests'
     chart: oauth2-proxy
-    targetRevision: 9.0.0
+    targetRevision: {{ .Values.chart_versions.oauth2_proxy }}
     helm:
       values: |-
           {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}

--- a/templates/qr-secrets-bootstrap+apps.yaml
+++ b/templates/qr-secrets-bootstrap+apps.yaml
@@ -58,7 +58,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: kubectl
-          image: bitnami/kubectl:latest
+          image: {{ .Values.container_images.app_kubectl.kubectl.image.registry }}/{{ .Values.container_images.app_kubectl.kubectl.image.repository }}:{{ .Values.container_images.app_kubectl.kubectl.image.tag }}
           command: ["/bin/sh","-c"]
           env:
             - name: NS_BOT
@@ -140,14 +140,14 @@ spec:
       selfHeal: true
     retry:
       backoff:
-        duration: 5s
+        duration: 10s
         maxDuration: 3m0s
         factor: 2
-      limit: 2
+      limit: 5
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.9.0
+    targetRevision: {{ .Values.chart_versions.project_template }}
     helm:
       values: |
         appName: 'pull-request-bot'
@@ -234,7 +234,7 @@ spec:
   source:
     repoURL: 'https://helm.gpkg.io/project-template'
     chart: app
-    targetRevision: 0.9.0
+    targetRevision: {{ .Values.chart_versions.project_template }}
     helm:
       values: |-
         appName: 'qr-code-generator'

--- a/templates/traefik-crds.yaml
+++ b/templates/traefik-crds.yaml
@@ -30,7 +30,7 @@ spec:
   sources:
     # 1) CRDs directory (applied first by wave)
     - repoURL: https://github.com/traefik/traefik-helm-chart.git
-      targetRevision: v39.0.0
+      targetRevision: {{ .Values.chart_versions.traefik_crds }}
       path: traefik-crds/crds-files/traefik
       directory:
         recurse: true
@@ -42,7 +42,7 @@ spec:
     # into that Traefik app’s values instead of creating a second Traefik release here.
     - repoURL: https://helm.gpkg.io/project-template
       chart: app
-      targetRevision: 0.9.0
+      targetRevision: {{ .Values.chart_versions.project_template }}
       helm:
         values: |
           appName: '{{ .Release.Name }}'

--- a/values.yaml
+++ b/values.yaml
@@ -486,12 +486,41 @@ container_images:
         registry: dockerhub.repo.gpkg.io
         repository: curlimages/curl
         tag: 8.16.0@sha256:463eaf6072688fe96ac64fa623fe73e1dbe25d8ad6c34404a669ad3ce1f104b6
+  app_kubectl:
+    kubectl:
+      image:
+        registry: dockerhub.repo.gpkg.io
+        repository: bitnami/kubectl
+        tag: "1.33.1"
   app_gluekube_ccm:
     gluekube_ccm:
       image:
         registry: ghcr.repo.gpkg.io
         repository: glueops/gluekube-ccm
         tag: v0.17.1@sha256:3d73666c4bb47b5ea0fc4838feecc1776ffffbfd82efed993ad8911f18566410
+
+chart_versions:
+  project_template: "0.9.0"
+  project_template_vault_init: "0.8.1"
+  traefik: "39.0.0"
+  traefik_crds: "v39.0.0"
+  cert_manager: "v1.18.2"
+  cert_reflector: "10.0.8"
+  external_secrets: "0.19.2"
+  external_dns: "external-dns-helm-chart-1.20.0"
+  kube_prometheus_stack: "59.1.0"
+  kube_prometheus_stack_crds: "kube-prometheus-stack-59.1.0"
+  loki: "5.48.0"
+  dex: "0.24.0"
+  openbao: "0.19.3"
+  keda: "2.17.2"
+  fluent_operator: "v2.7.0"
+  metacontroller: "v4.12.5"
+  descheduler: "v0.33.0"
+  oauth2_proxy: "9.0.0"
+  glueops_grafana_dashboards: "v0.12.1"
+  nginx: "4.13.3"
+  promtail: "6.15.5"
 
 enable_chisel_proxy_protocol: false
 


### PR DESCRIPTION
centralize chart versions, fix bugs, and standardize retry policies

Bug fixes:
- Fix KEDA duplicate YAML keys: merged duplicate `prometheus:` and `metricServer:` keys that caused `metricServer.enabled: true` to be silently overwritten (application-keda.yaml)
- Fix network-exporter DaemonSet missing metadata labels: added app.kubernetes.io/instance and app.kubernetes.io/name labels to match the pod template and Service selectors (application-network-exporter.yaml)
- Replace unversioned `bitnami/kubectl:latest` with pinned image referenced from container_images in values.yaml (qr-secrets-bootstrap+apps.yaml)

Chart version centralization:
- Add `chart_versions` section to values.yaml containing all 21 chart versions previously hardcoded across 30+ template files
- Update all templates to reference `{{ .Values.chart_versions.* }}` instead of hardcoded strings, enabling single-point version management
- Only `HEAD` (captain-manifests git ref) remains hardcoded intentionally

Retry policy standardization:
- Normalize all ArgoCD Application retry policies to `limit: 5`, `duration: 10s`, `maxDuration: 3m0s`, `factor: 2`
- Previously had inconsistent values: limit 2/5/10 and duration 5s/10s/60s
- Vault outer app retains `duration: 30s` (intentional for slower startup)

Cleanup:
- Remove trailing whitespace from `- CreateNamespace=true` syncOptions lines across 8 template files