### PR TITLE
feat(kube-api): glueops-core-kube-api ns to expose kube api service via Traefik and surface cluster CA on cluster-info page

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This chart deploys the GlueOps Platform
 | container_images.app_cert_manager.cert_restore.image.tag | string | `"v0.12.8@sha256:1edd17bfd8737b7231c17fc93167be1ad16fa025f9b237e01fbf39a4df76117d"` |  |
 | container_images.app_cluster_info_page.cluster_information_help_page_html.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
 | container_images.app_cluster_info_page.cluster_information_help_page_html.image.repository | string | `"glueops/cluster-information-help-page-html"` |  |
-| container_images.app_cluster_info_page.cluster_information_help_page_html.image.tag | string | `"v4.1.0@sha256:e7a1c1b6dca8b79e362f6eadefbd15417b9ae5816d22f476c5f0a6a8b4fb594e"` |  |
+| container_images.app_cluster_info_page.cluster_information_help_page_html.image.tag | string | `"v4.23.0@sha256:ff9ab76848c696038b997d562f580ffafe2511d04ba746c7b5cf7fed1ee8a65b"` |  |
 | container_images.app_curlimages.curl.image.registry | string | `"dockerhub.repo.gpkg.io"` |  |
 | container_images.app_curlimages.curl.image.repository | string | `"curlimages/curl"` |  |
 | container_images.app_curlimages.curl.image.tag | string | `"8.16.0@sha256:463eaf6072688fe96ac64fa623fe73e1dbe25d8ad6c34404a669ad3ce1f104b6"` |  |

--- a/templates/application-cluster-info-page.yaml
+++ b/templates/application-cluster-info-page.yaml
@@ -54,6 +54,12 @@ spec:
               value: "{{ .Values.captain_domain }}"
             - name: INTERNAL_LB_ENABLED
               value: "{{ if .Values.traefik.internal_lb.enabled }}TRUE{{ else }}FALSE{{ end }}"
+            - name: KUBEADM_ENABLED
+              value: "{{ if .Values.kubeadm.enabled }}TRUE{{ else }}FALSE{{ end }}"
+          envConfigMaps:
+            - variable: CLUSTER_CA_CERTIFICATE
+              configMapName: kube-root-ca.crt
+              configMapKey: ca.crt
         
         ingress:
           enabled: true

--- a/templates/application-cluster-info-page.yaml
+++ b/templates/application-cluster-info-page.yaml
@@ -56,10 +56,12 @@ spec:
               value: "{{ if .Values.traefik.internal_lb.enabled }}TRUE{{ else }}FALSE{{ end }}"
             - name: KUBEADM_ENABLED
               value: "{{ if .Values.kubeadm.enabled }}TRUE{{ else }}FALSE{{ end }}"
+          {{ if .Values.kubeadm.enabled }}
           envConfigMaps:
             - variable: CLUSTER_CA_CERTIFICATE
               configMapName: kube-root-ca.crt
               configMapKey: ca.crt
+          {{ end }}
         
         ingress:
           enabled: true

--- a/templates/application-traefik-platform.yaml
+++ b/templates/application-traefik-platform.yaml
@@ -50,6 +50,7 @@ spec:
               - glueops-core-oauth2-proxy
               - glueops-core-vault
               - glueops-core-kube-prometheus-stack
+              - default
       
         {{- if .Values.kubeadm.enabled }}
         nodeSelector:

--- a/templates/application-traefik-platform.yaml
+++ b/templates/application-traefik-platform.yaml
@@ -51,6 +51,7 @@ spec:
               - glueops-core-vault
               - glueops-core-kube-prometheus-stack
               - default
+              - glueops-core-expose-kube-api
       
         {{- if .Values.kubeadm.enabled }}
         nodeSelector:

--- a/templates/application-traefik-platform.yaml
+++ b/templates/application-traefik-platform.yaml
@@ -51,7 +51,7 @@ spec:
               - glueops-core-vault
               - glueops-core-kube-prometheus-stack
               - default
-              - glueops-core-expose-kube-api
+              - glueops-core-kube-api
       
         {{- if .Values.kubeadm.enabled }}
         nodeSelector:

--- a/values.yaml
+++ b/values.yaml
@@ -383,7 +383,7 @@ container_images:
       image:
         registry: ghcr.repo.gpkg.io
         repository: glueops/cluster-information-help-page-html
-        tag: v4.1.0@sha256:e7a1c1b6dca8b79e362f6eadefbd15417b9ae5816d22f476c5f0a6a8b4fb594e
+        tag: v4.23.0@sha256:ff9ab76848c696038b997d562f580ffafe2511d04ba746c7b5cf7fed1ee8a65b
   app_dex:
     dex:
       image:


### PR DESCRIPTION
## What

Two related changes that support direct `kubectl` access to the cluster:

**1. Traefik — allow the kube-api exposure namespaces** (`application-traefik-platform.yaml`)
Adds `default` and `glueops-core-expose-kube-api` to Traefik's allowed namespaces so the kube-api can be exposed through the platform ingress.

**2. Cluster-info page — surface the cluster CA + kubeadm flag** (`application-cluster-info-page.yaml`)
Adds two env vars to the `glueops-cluster-info-page` app so the page can help users build a kubeconfig:
- **`CLUSTER_CA_CERTIFICATE`** — the cluster's public CA (raw PEM), sourced from the per-namespace `kube-root-ca.crt` ConfigMap via the chart's `envConfigMaps` → `configMapKeyRef`. Named to match managed-provider convention (GKE/AKS/DOKS/Terraform all use `cluster_ca_certificate`).
- **`KUBEADM_ENABLED`** — `TRUE`/`FALSE` from `.Values.kubeadm.enabled`, consistent with the existing `INTERNAL_LB_ENABLED`.

## Notes

- The CA value is **raw PEM** — the HTML app must base64-encode it for kubeconfig `certificate-authority-data`.
- `kube-root-ca.crt` is auto-published in every namespace (RootCAConfigMap, GA since k8s 1.21); no RBAC needed (`configMapKeyRef` is kubelet-resolved). Public, non-sensitive material.
- `KUBEADM_ENABLED` uses the `{{ if }}` form deliberately: the `placeholder_*` value substitutes into a real YAML bool at deploy, and a string filter like `| upper` errors on a bool.

## ⚠️ Open item

`kube-root-ca.crt` is the **in-cluster** CA — correct only when the exposed apiserver endpoint chains to it (e.g. kubeadm, or TLS-passthrough). If the kube-api is exposed with TLS **terminated at Traefik** (its own cert), the correct `certificate-authority-data` is Traefik's CA, not this one. Confirm the exposure model and have the page gate the CA on `KUBEADM_ENABLED` accordingly.

## Follow-up

The cluster-info HTML app (`glueops/cluster-information-help-page-html`) must read `CLUSTER_CA_CERTIFICATE` to display it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)