### PR TITLE
chore: ignore Renovate updates for platform-managed monitoring/logging apps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
         "templates/application-kube-prometheus-stack-crds.yaml",
         "templates/application-kube-prometheus-stack.yaml",
         "templates/application-loki.yaml",
-        "templates/application-fluent-operator.yaml"
+        "templates/application-fluent-operator.yaml",
+        "templates/application-glueops-grafana-dashboards.yaml"
       ],
       "enabled": false
     },

--- a/renovate.json
+++ b/renovate.json
@@ -8,18 +8,22 @@
         "templates/application-kube-prometheus-stack.yaml",
         "templates/application-loki.yaml",
         "templates/application-fluent-operator.yaml",
-        "templates/application-glueops-grafana-dashboards.yaml"
+        "templates/application-glueops-grafana-dashboards.yaml",
+        "templates/application-promtail.yaml",
+        "templates/application-loki-alert-group-controller.yaml"
       ],
       "enabled": false
     },
     {
-      "description": "Ignore container image updates in values.yaml ONLY for the images consumed by the apps above (kube-prometheus-stack/grafana, loki, fluent-operator). All other values.yaml images still get PRs.",
+      "description": "Ignore container image updates in values.yaml ONLY for the images consumed by the apps above (kube-prometheus-stack/grafana, loki, fluent-operator, promtail, loki-alert-group-controller). All other values.yaml images still get PRs.",
       "matchFileNames": ["values.yaml"],
       "matchDatasources": ["docker"],
       "matchPackageNames": [
         "grafana/grafana",
         "grafana/loki",
-        "kubesphere/fluent-operator"
+        "kubesphere/fluent-operator",
+        "grafana/promtail",
+        "glueops/metacontroller-operator-loki-rule-group"
       ],
       "enabled": false
     }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Ignore platform-managed monitoring/logging Argo CD app manifests (chart versions are bumped via the platform release process, not Renovate). Scoped to this repo only.",
+      "matchFileNames": [
+        "templates/application-kube-prometheus-stack-crds.yaml",
+        "templates/application-kube-prometheus-stack.yaml",
+        "templates/application-loki.yaml",
+        "templates/application-fluent-operator.yaml"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Ignore container image updates in values.yaml ONLY for the images consumed by the apps above (kube-prometheus-stack/grafana, loki, fluent-operator). All other values.yaml images still get PRs.",
+      "matchFileNames": ["values.yaml"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "grafana/grafana",
+        "grafana/loki",
+        "kubesphere/fluent-operator"
+      ],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a repo-local `renovate.json` to `platform-helm-chart-platform` to silence the recurring Renovate PRs for the platform-managed monitoring/logging Argo CD apps.

This works because the self-hosted bot (`GlueOps/renovatebot`) runs with `RENOVATE_REQUIRE_CONFIG: "ignored"` — repos don't need their own config, but if one exists it's **merged** with the forced shared presets (`base` + `defaults`). Repo-local `packageRules` are appended after the preset rules, so the `enabled: false` carve-outs win. **Scoped to this repo only** — other repos that extend the same presets are unaffected.

## What gets ignored

**1. App manifest / Helm chart version updates** (the `targetRevision` bumps) for:
- `templates/application-kube-prometheus-stack-crds.yaml`
- `templates/application-kube-prometheus-stack.yaml`
- `templates/application-loki.yaml`
- `templates/application-fluent-operator.yaml`

**2. Container image updates in `values.yaml`** — only the images consumed by those apps:
- `grafana/grafana` (kube-prometheus-stack)
- `grafana/loki` (loki)
- `kubesphere/fluent-operator` (fluent-operator)

## What still gets PRs (intentionally)

All other `values.yaml` images — traefik, cert-manager, external-secrets, external-dns, descheduler, `grafana/promtail`, the loki-alert-group-controller image, etc. — plus everything in other repos.
