### PR TITLE
fix(renovate): match registry-qualified image names for ignored values.yaml images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,15 +15,15 @@
       "enabled": false
     },
     {
-      "description": "Ignore container image updates in values.yaml ONLY for the images consumed by the apps above (kube-prometheus-stack/grafana, loki, fluent-operator, promtail, loki-alert-group-controller). All other values.yaml images still get PRs.",
+      "description": "Ignore container image updates in values.yaml ONLY for the images consumed by the apps above (kube-prometheus-stack/grafana, loki, fluent-operator, promtail, loki-alert-group-controller). Regex anchors are registry-agnostic because depName is registry-qualified (e.g. dockerhub.repo.gpkg.io/grafana/loki). All other values.yaml images still get PRs.",
       "matchFileNames": ["values.yaml"],
       "matchDatasources": ["docker"],
       "matchPackageNames": [
-        "grafana/grafana",
-        "grafana/loki",
-        "kubesphere/fluent-operator",
-        "grafana/promtail",
-        "glueops/metacontroller-operator-loki-rule-group"
+        "/grafana\\/grafana$/",
+        "/grafana\\/loki$/",
+        "/grafana\\/promtail$/",
+        "/kubesphere\\/fluent-operator$/",
+        "/metacontroller-operator-loki-rule-group$/"
       ],
       "enabled": false
     }


### PR DESCRIPTION
## Why

After #1371 merged, the first Renovate run did **not** close the expected PRs. Digging into the [run logs](https://github.com/GlueOps/renovatebot/actions/runs/28363531036/job/84023762727) showed two issues:

### 1. Image-ignore rule never matched (fixed here)
The `values.yaml` images are extracted with **registry-qualified** names, e.g. `dockerhub.repo.gpkg.io/grafana/loki`, `ghcr.repo.gpkg.io/glueops/metacontroller-operator-loki-rule-group`. The previous `matchPackageNames: ["grafana/loki", ...]` did an exact match and never hit.

This PR switches to registry-agnostic regex anchors (`/grafana\/loki$/`, etc.) so they match regardless of the gpkg.io mirror prefix.

### 2. First-run timing (no code change needed)
In that same run, Renovate evaluated every dependency at 09:52 and only detected the repo's `renovate.json` at 09:52→`Found renovate.json config file` logged at 10:01 (end of run). The file landed on `main` ~45s before the run cloned, so the config wasn't applied during evaluation that one time. Subsequent scheduled runs load it normally from the start.

## Net effect
- Chart/app updates: still disabled via `matchFileNames` on the 7 `templates/application-*.yaml` files.
- Images in `values.yaml`: now correctly disabled for grafana, loki, promtail, fluent-operator, and the loki-rule-group controller — and **only** those.
- Everything else (traefik, cert-manager, external-secrets, external-dns, descheduler, etc.) still gets PRs.

Once merged, the next Renovate run should auto-close the now-disabled open PRs (presets set `dependencyDashboardAutoclose: true` / `recreateWhen: always`).
