### PR TITLE
ci: fix OCI push URL missing ghcr.io registry host

### DIFF
--- a/.github/workflows/oci-publish.yaml
+++ b/.github/workflows/oci-publish.yaml
@@ -27,5 +27,5 @@ jobs:
         run: |
           echo "$GITHUB_TOKEN" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
           helm package .
-          helm push glueops-platform-*.tgz "oci://${{ steps.repo.outputs.path }}"
+          helm push glueops-platform-*.tgz "oci://ghcr.io/${{ steps.repo.outputs.path }}"
           helm registry logout ghcr.io


### PR DESCRIPTION
Follow-up fix to the OCI publish workflow added in #1378.

## What broke
The `v0.73.0` release tag triggered `oci-publish.yaml`, and the push step failed:

```
helm push glueops-platform-*.tgz "oci://glueops/platform-helm-chart-platform"
Error: failed to perform "Exists" on destination: Head "https://glueops/v2/...":
dial tcp: lookup glueops on 127.0.0.53:53: server misbehaving
```

`steps.repo.outputs.path` is `${{ github.repository }}` lowercased = `glueops/platform-helm-chart-platform` — with **no registry host**. So `oci://glueops/...` made helm treat `glueops` as the registry hostname and fail DNS resolution. (`helm registry login ghcr.io` and `helm package` both succeeded; only the push URL was wrong.)

## Fix
Prefix the registry host:

```
helm push glueops-platform-*.tgz "oci://ghcr.io/${{ steps.repo.outputs.path }}"
```

Final coordinates unchanged from the intent: `ghcr.io/glueops/platform-helm-chart-platform/glueops-platform:X.Y.Z`.

## Verification
Reproduced the exact failure and validated the fix by replicating the workflow's precise path computation + URL assembly against a local OCI registry (swapping only `ghcr.io` → local host): `helm package` → `helm push` → `helm pull` round-trips cleanly at `.../glueops-platform:0.73.0`. `actionlint` clean.

Note: the earlier verification for #1378 hardcoded the full `oci://<registry>/...` URL instead of exercising the `oci://${{ steps.repo.outputs.path }}` expression, which is why the missing host slipped through. This test now uses the exact expression.

## After merge
Re-run the failed `v0.73.0` OCI publish (or it will publish correctly on the next release tag). The S3 publish for `v0.73.0` was unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)