### PR TITLE
feat: de-fang kube-prometheus-stack-crds app ahead of its removal

### DIFF
--- a/templates/application-kube-prometheus-stack-crds.yaml
+++ b/templates/application-kube-prometheus-stack-crds.yaml
@@ -1,11 +1,18 @@
+# De-fanged ahead of removal in a following release: the resources-finalizer and
+# automated sync policy are gone so the Application can be deleted non-cascadingly.
+# POST-DEPLOYMENT STEP (run after `helm upgrade` with this change, and before the
+# follow-up release deletes this file): confirm the live Application carries no
+# finalizer, otherwise its deletion cascades and wipes the kube-prometheus-stack
+# CRDs and every monitoring CR cluster-wide.
+#   kubectl get application kube-prometheus-stack-crds -n glueops-core -o jsonpath='{.metadata.finalizers}'
+# Expect empty output. If it is non-empty, strip it before the removal release:
+#   kubectl patch application kube-prometheus-stack-crds -n glueops-core --type merge -p '{"metadata":{"finalizers":null}}'
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: kube-prometheus-stack-crds
   annotations:
     argocd.argoproj.io/sync-wave: "1"
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     name: "in-cluster"
@@ -14,9 +21,6 @@ spec:
   syncPolicy:
     syncOptions:
       - Replace=true
-    automated:
-      prune: true
-      selfHeal: true
     retry:
       backoff:
         duration: 10s


### PR DESCRIPTION
## Summary
Release N of a two-release removal of the `kube-prometheus-stack-crds` Application, now that the CRDs are installed by captain_utils via `kubectl apply --server-side` (GlueOps/codespaces#515, version plumbed through `VERSIONS/glueops.yaml` by GlueOps/terraform-module-cloud-multy-prerequisites#648):

- Drop `resources-finalizer.argocd.argoproj.io` — with the finalizer present, deleting the Application cascade-deletes all nine kube-prometheus-stack CRDs, and Kubernetes then garbage-collects **every ServiceMonitor/PrometheusRule/Prometheus/Alertmanager/etc. CR cluster-wide** (monitoring outage). Without it, deletion is non-cascading and the CRDs orphan in place under kubectl's ownership. Per ArgoCD docs, only the finalizer (not `prune`) controls cascading app deletion.
- Drop `automated` (prune + selfHeal) — freezes the app so `selfHeal` + `Replace=true` can't revert kubectl-applied CRD updates if `VERSIONS/glueops.yaml` moves ahead of this app's pinned tag during the transition.

## Rollout order
1. This release (N): clusters upgrade, the live Application loses its finalizer and automated sync via Helm's three-way merge.
2. Release N+1 (follow-up PR): delete `templates/application-kube-prometheus-stack-crds.yaml` entirely. Do **not** remove the template before all clusters have taken release N — deleting the app while it still has the finalizer causes the cascade above.

The app remains fully functional in the meantime (manual sync still works, `Replace=true` retained).

## Post-deployment step
After `helm upgrade` with this change (and before the follow-up release deletes the file), confirm the live Application no longer carries a finalizer. If it still does, the removal release will cascade-delete the CRDs and every monitoring CR cluster-wide.

```sh
kubectl get application kube-prometheus-stack-crds -n glueops-core -o jsonpath='{.metadata.finalizers}'
```

Expect empty output. If it is non-empty, strip it before the removal release:

```sh
kubectl patch application kube-prometheus-stack-crds -n glueops-core --type merge -p '{"metadata":{"finalizers":null}}'
```

BREAKING CHANGE: after upgrading, and before the follow-up release deletes this Application, verify it has no finalizer — otherwise the delete cascades and wipes the kube-prometheus-stack CRDs and all monitoring CRs. Verify with `kubectl get application kube-prometheus-stack-crds -n glueops-core -o jsonpath='{.metadata.finalizers}'` and expect empty output; if it is non-empty, strip it first with `kubectl patch application kube-prometheus-stack-crds -n glueops-core --type merge -p '{"metadata":{"finalizers":null}}'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
