### PR TITLE
feat: deploy argocd-extension-backend via the app chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This chart deploys the GlueOps Platform
 | certManager.aws_secretKey | string | `"placeholder_certmanager_aws_secret_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | container_images.app_argocd_extension_backend.argocd_extension_backend.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
 | container_images.app_argocd_extension_backend.argocd_extension_backend.image.repository | string | `"glueops/argocd-extension-backend-api"` |  |
-| container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag | string | `"v0.1.1"` |  |
+| container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag | string | `"v.0.0.1@sha256:fefde17e4a2223eea3a94ab4a864cfb40a340c6ce8b3b3ad578ef5a0154adfe3"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.repository | string | `"glueops/backup-tools"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.tag | string | `"v2.7.0@sha256:64e194438f3d056b4a658978be30cd06dce2d37e8df65db611b65aad0e7c3231"` |  |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This chart deploys the GlueOps Platform
 | certManager.aws_accessKey | string | `"placeholder_certmanager_aws_access_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | certManager.aws_region | string | `"placeholder_aws_region"` | Should be the same `primary_region` you used in: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | certManager.aws_secretKey | string | `"placeholder_certmanager_aws_secret_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
+| container_images.app_argocd_extension_backend.argocd_extension_backend.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
+| container_images.app_argocd_extension_backend.argocd_extension_backend.image.repository | string | `"glueops/argocd-extension-backend-api"` |  |
+| container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag | string | `"v0.1.1"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.repository | string | `"glueops/backup-tools"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.tag | string | `"v2.7.0@sha256:64e194438f3d056b4a658978be30cd06dce2d37e8df65db611b65aad0e7c3231"` |  |

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -1,0 +1,258 @@
+{{- /*
+Deploys the Argo CD UI extension backend (github.com/GlueOps/argo-cd-extention-backend)
+via the shared `app` chart, following the same pattern as the other platform
+components (see application-go-healthz.yaml / application-network-exporter.yaml).
+
+Cluster environment (e.g. "nonprod") is the first label of captain_domain and is
+used as the tenant destination namespace the backend serves.
+
+VERIFY BEFORE MERGE (namespace correction vs the standalone manifests):
+  The standalone chart/manifests in the backend repo scoped the app-namespace gate
+  and the NetworkPolicy source to a namespace literally named "argocd". On GlueOps
+  clusters Argo CD (server + Application CRs) runs in "glueops-core" (see the real
+  Application manifests, project glueops-core). This template therefore uses
+  glueops-core for both. If your Argo CD server actually runs elsewhere, adjust
+  `networkPolicyArgocdNamespace` and the ALLOWED_APP/ARGOCD_APP namespaces below.
+*/ -}}
+{{- $env := .Values.captain_domain | splitList "." | first -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: glueops-argocd-extension-backend
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    name: "in-cluster"
+    namespace: glueops-core-argocd-extension-backend
+  project: glueops-core
+  syncPolicy:
+    syncOptions:
+      - Replace=true
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      backoff:
+        duration: 5s
+        maxDuration: 3m0s
+        factor: 2
+      limit: 2
+  source:
+    repoURL: https://helm.gpkg.io/project-template
+    chart: app
+    targetRevision: 0.13.0
+    helm:
+      values: |
+        appName: 'argocd-extension-backend-api'
+        appVersion: '0.1.1'
+
+        image:
+          port: 8000
+          registry: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.registry }}
+          repository: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.repository }}
+          tag: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag }}
+          pullPolicy: IfNotPresent
+
+        serviceAccount:
+          create: true
+          name: argocd-extension-backend-api
+
+        service:
+          enabled: true
+          port: 8000
+
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
+
+        deployment:
+          {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
+          enabled: true
+          replicas: 2
+          imagePullPolicy: IfNotPresent
+          strategy: RollingUpdate
+          maxUnavailable: "0"
+          maxSurge: 1
+
+          serviceAccount:
+            enabled: true
+            automountServiceAccountToken: true
+
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+
+          containerSecurityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-extension-backend-api
+                  app.kubernetes.io/instance: glueops-argocd-extension-backend
+
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            failureThreshold: 30
+            periodSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+
+          volumes:
+            - name: tmp
+              emptyDir: {}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+
+          envMap:
+            PORT:
+              value: "8000"
+            LOG_LEVEL:
+              value: "INFO"
+            REQUEST_TIMEOUT_MS:
+              value: "8000"
+            TEMPO_SEARCH_PATH:
+              value: "/api/search"
+            TEMPO_BASE_URL:
+              value: ""
+            PROMETHEUS_BASE_URL:
+              value: "http://kps-prometheus.glueops-core-kube-prometheus-stack.svc.cluster.local:9090"
+            GRAFANA_BASE_URL:
+              value: "https://grafana.{{ .Values.captain_domain }}"
+            VAULT_BASE_URL:
+              value: "https://vault.{{ .Values.captain_domain }}"
+            DEPLOYMENT_CONFIG_REPO_URL:
+              value: "https://github.com/GlueOps/deployment-configurations"
+            CONFIG_REPO_LOCAL_ROOT:
+              value: ""
+            GRAFANA_LOGS_DASHBOARD:
+              value: ""
+            GRAFANA_METRICS_DASHBOARD:
+              value: ""
+            GRAFANA_TRACES_DASHBOARD:
+              value: ""
+            # Application CRs live in glueops-core (see VERIFY note above).
+            ARGOCD_APP_NAMESPACES:
+              value: "glueops-core"
+            ALLOWED_APP_NAMESPACES:
+              value: "glueops-core"
+            # Destination namespace this cluster's apps deploy into = the environment.
+            ALLOWED_DEST_NAMESPACES:
+              value: "{{ $env }}"
+            ALLOWED_NAMESPACES:
+              value: "{{ $env }}"
+
+        # RBAC + NetworkPolicy are not first-class in the app chart, so they go through
+        # customResources. Names/labels are LITERAL (the app chart's tpl runs on these
+        # but they contain no template expressions) — instance label = this Application's
+        # name (the Helm release name Argo CD uses).
+        customResources:
+          # NetworkPolicy: only argocd-server (in glueops-core) may reach the backend.
+          - |-
+            apiVersion: networking.k8s.io/v1
+            kind: NetworkPolicy
+            metadata:
+              name: argocd-extension-backend-api
+              namespace: glueops-core-argocd-extension-backend
+            spec:
+              podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-extension-backend-api
+                  app.kubernetes.io/instance: glueops-argocd-extension-backend
+              policyTypes:
+                - Ingress
+              ingress:
+                - from:
+                    - namespaceSelector:
+                        matchLabels:
+                          kubernetes.io/metadata.name: glueops-core
+                      podSelector:
+                        matchLabels:
+                          app.kubernetes.io/name: argocd-server
+                  ports:
+                    - protocol: TCP
+                      port: 8000
+          # argoproj.io Applications: get/list, CLUSTER-WIDE (always).
+          - |-
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRole
+            metadata:
+              name: argocd-extension-backend-api-applications
+            rules:
+              - apiGroups: ["argoproj.io"]
+                resources: ["applications"]
+                verbs: ["get", "list"]
+          - |-
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              name: argocd-extension-backend-api-applications
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: argocd-extension-backend-api-applications
+            subjects:
+              - kind: ServiceAccount
+                name: argocd-extension-backend-api
+                namespace: glueops-core-argocd-extension-backend
+          # Workload/ExternalSecret list: namespaced Role in the destination namespace.
+          - |-
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: argocd-extension-backend-api-workloads
+              namespace: {{ $env }}
+            rules:
+              - apiGroups: ["apps"]
+                resources: ["deployments", "statefulsets", "daemonsets"]
+                verbs: ["list"]
+              - apiGroups: ["external-secrets.io"]
+                resources: ["externalsecrets"]
+                verbs: ["list"]
+          - |-
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: RoleBinding
+            metadata:
+              name: argocd-extension-backend-api-workloads
+              namespace: {{ $env }}
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: Role
+              name: argocd-extension-backend-api-workloads
+            subjects:
+              - kind: ServiceAccount
+                name: argocd-extension-backend-api
+                namespace: glueops-core-argocd-extension-backend

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -19,6 +19,12 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: glueops-argocd-extension-backend
+  annotations:
+    # Sync after captain-manifests (sync-wave 20), which creates the tenant
+    # environment namespace ($env). The Role/RoleBinding below live in that
+    # namespace, so without this they can fail on the initial sync until the
+    # namespace exists.
+    argocd.argoproj.io/sync-wave: "21"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -52,7 +52,7 @@ spec:
     helm:
       values: |
         appName: 'argocd-extension-backend-api'
-        appVersion: '0.1.1'
+        appVersion: '0.0.1'
 
         image:
           port: 8000

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -252,7 +252,7 @@ spec:
             kind: Role
             metadata:
               name: argocd-extension-backend-api-workloads
-              namespace: {{ $env }}
+              namespace: {{ $env | quote }}
             rules:
               - apiGroups: ["apps"]
                 resources: ["deployments", "statefulsets", "daemonsets"]
@@ -265,7 +265,7 @@ spec:
             kind: RoleBinding
             metadata:
               name: argocd-extension-backend-api-workloads
-              namespace: {{ $env }}
+              namespace: {{ $env | quote }}
             roleRef:
               apiGroup: rbac.authorization.k8s.io
               kind: Role

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -182,9 +182,11 @@ spec:
               value: "{{ $env }}"
 
         # RBAC + NetworkPolicy are not first-class in the app chart, so they go through
-        # customResources. Names/labels are LITERAL (the app chart's tpl runs on these
-        # but they contain no template expressions) — instance label = this Application's
-        # name (the Helm release name Argo CD uses).
+        # customResources. Two templating phases apply: this platform chart (Helm)
+        # renders its own expressions first (e.g. `{{ $env }}` below becomes a literal
+        # namespace), then the app chart runs `tpl` on the result. By that second phase
+        # the strings are already literal, so the app chart's `tpl` is a no-op here.
+        # Instance label = this Application's name (the Helm release name Argo CD uses).
         customResources:
           # NetworkPolicy: only argocd-server (in glueops-core) may reach the backend.
           - |-
@@ -211,24 +213,30 @@ spec:
                   ports:
                     - protocol: TCP
                       port: 8000
-          # argoproj.io Applications: get/list, CLUSTER-WIDE (always).
+          # argoproj.io Applications: get/list, scoped to glueops-core — where the
+          # Application CRs live (see ARGOCD_APP_NAMESPACES above). `applications` is a
+          # namespaced resource and the backend only reads from glueops-core, so a
+          # namespaced Role + RoleBinding is sufficient (least privilege, no cluster-wide
+          # grant). The bound ServiceAccount lives in the backend's own namespace.
           - |-
             apiVersion: rbac.authorization.k8s.io/v1
-            kind: ClusterRole
+            kind: Role
             metadata:
               name: argocd-extension-backend-api-applications
+              namespace: glueops-core
             rules:
               - apiGroups: ["argoproj.io"]
                 resources: ["applications"]
                 verbs: ["get", "list"]
           - |-
             apiVersion: rbac.authorization.k8s.io/v1
-            kind: ClusterRoleBinding
+            kind: RoleBinding
             metadata:
               name: argocd-extension-backend-api-applications
+              namespace: glueops-core
             roleRef:
               apiGroup: rbac.authorization.k8s.io
-              kind: ClusterRole
+              kind: Role
               name: argocd-extension-backend-api-applications
             subjects:
               - kind: ServiceAccount

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -6,13 +6,14 @@ components (see application-go-healthz.yaml / application-network-exporter.yaml)
 Cluster environment (e.g. "nonprod") is the first label of captain_domain and is
 used as the tenant destination namespace the backend serves.
 
-VERIFY BEFORE MERGE (namespace correction vs the standalone manifests):
+Argo CD namespace assumption (correction vs the standalone manifests):
   The standalone chart/manifests in the backend repo scoped the app-namespace gate
   and the NetworkPolicy source to a namespace literally named "argocd". On GlueOps
   clusters Argo CD (server + Application CRs) runs in "glueops-core" (see the real
-  Application manifests, project glueops-core). This template therefore uses
-  glueops-core for both. If your Argo CD server actually runs elsewhere, adjust
-  `networkPolicyArgocdNamespace` and the ALLOWED_APP/ARGOCD_APP namespaces below.
+  Application manifests, project glueops-core), so this template uses glueops-core
+  for both. If your Argo CD server runs elsewhere, change it in the two places
+  below: the NetworkPolicy `namespaceSelector` (kubernetes.io/metadata.name:
+  glueops-core) and the ARGOCD_APP_NAMESPACES / ALLOWED_APP_NAMESPACES env vars.
 */ -}}
 {{- $env := .Values.captain_domain | splitList "." | first -}}
 apiVersion: argoproj.io/v1alpha1
@@ -170,7 +171,7 @@ spec:
               value: ""
             GRAFANA_TRACES_DASHBOARD:
               value: ""
-            # Application CRs live in glueops-core (see VERIFY note above).
+            # Application CRs live in glueops-core (see Argo CD namespace note above).
             ARGOCD_APP_NAMESPACES:
               value: "glueops-core"
             ALLOWED_APP_NAMESPACES:

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -49,7 +49,10 @@ spec:
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.13.0
+    # Pinned to the same app-chart version as the other platform components
+    # (application-go-healthz.yaml, application-network-exporter.yaml, …) to avoid
+    # version drift. Renders identically to 0.13.0 for these values (verified).
+    targetRevision: 0.9.0
     helm:
       values: |
         appName: 'argocd-extension-backend-api'

--- a/values.yaml
+++ b/values.yaml
@@ -332,6 +332,12 @@ base_registries:
   registry_k8s_io: "k8s.repo.gpkg.io"
 
 container_images:
+  app_argocd_extension_backend:
+    argocd_extension_backend:
+      image:
+        registry: ghcr.repo.gpkg.io
+        repository: glueops/argocd-extension-backend-api
+        tag: v0.1.1
   app_cert_manager:
     cert_manager:
       image:

--- a/values.yaml
+++ b/values.yaml
@@ -337,7 +337,7 @@ container_images:
       image:
         registry: ghcr.repo.gpkg.io
         repository: glueops/argocd-extension-backend-api
-        tag: v0.1.1
+        tag: v.0.0.1@sha256:fefde17e4a2223eea3a94ab4a864cfb40a340c6ce8b3b3ad578ef5a0154adfe3
   app_cert_manager:
     cert_manager:
       image:


### PR DESCRIPTION
## What

Adds the Argo CD UI extension backend ([argo-cd-extention-backend](https://github.com/GlueOps/argo-cd-extention-backend)) as a platform component, deployed through the shared `app` chart like every other component (go-healthz, network-exporter, …):

- **`templates/application-argocd-extension-backend.yaml`** — an Argo CD `Application` with inline `helm.values`, image from `container_images`, node/tolerations from `glueops_node_and_tolerations`, and RBAC + NetworkPolicy via `customResources` (literal names). Cluster-agnostic: the destination namespace and Grafana/Vault URLs derive from `.Values.captain_domain`.
- **`values.yaml`** — new `container_images.app_argocd_extension_backend` entry (via the `ghcr.repo.gpkg.io` mirror).

This answers the review question on the backend repo (why not use the app chart) by deploying it the standard GlueOps way — here, in the platform chart — rather than shipping a bespoke chart.

## ⚠️ Please confirm — namespace correction

The backend's standalone manifests scoped the app-namespace gate and the NetworkPolicy **source** to a namespace literally named `argocd`. On GlueOps clusters Argo CD (server + Application CRs) runs in **`glueops-core`** (per the real tenant Application manifests). Using the standalone `argocd` value here would make the NetworkPolicy **block the real argocd-server and break the extension**, so this template uses `glueops-core` for both. Flagged in-file — confirm this matches where your argocd-server runs.

## Scope

Covers the tenant model (backend in `glueops-core-argocd-extension-backend`, serving the cluster's environment namespace, derived from `captain_domain`). A captain-style Argo CD on a separate cluster is covered by the same template with that cluster's `captain_domain`.

## Verification

- Platform chart renders (lint clean).
- The Application's inline values render the `app` chart (`0.9.0`, aligned with the other platform components) to **9 resources**; `kubeconform -strict` passes **9/9**.
- The NetworkPolicy podSelector **matches** the Deployment pod labels under the Argo CD release name (so it selects the real pods).
- Render-equivalent to the previously-validated backend-repo overlays.

Supersedes GlueOps/argo-cd-extention-backend#39 (which put the same config in the backend repo); that PR is being closed in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
