### PR TITLE
fix: collapse Renovate per-minor PR sprawl

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Collapse per-minor PR sprawl. The org preset separates every intermediate minor/patch into its own PR (branches like ...-2.5.x, ...-2.6.x), so a single image can accumulate a dozen open PRs. Overriding these to false makes Renovate open one PR per dependency targeting the highest available version; older intermediate PRs are superseded automatically. Majors stay separate (default separateMajorMinor) so breaking changes are still reviewed on their own.",
+  "separateMinorPatch": false,
+  "separateMultipleMinor": false,
   "packageRules": [
     {
       "description": "Ignore platform-managed monitoring/logging Argo CD app manifests (chart versions are bumped via the platform release process, not Renovate). Scoped to this repo only.",


### PR DESCRIPTION
## Problem

The org-level Renovate preset separates every intermediate minor/patch into its own PR — branches like `...-2.5.x`, `...-2.6.x`, `...-2.18.x` (Renovate's default is one branch per *major*, `...-2.x`). As a result a single image accumulates many open PRs that never collapse. Example: `glueops/vault-backup-validator` had **14** simultaneous open PRs (v2.5.1 → v2.18.0).

Manually closing the superseded ones does not help — Renovate regenerates them on its next run against `main`.

## Fix

Override the separation settings at the repo level:

```json
"separateMinorPatch": false,
"separateMultipleMinor": false
```

Renovate now opens **one PR per dependency**, targeting the highest available version; older intermediate PRs are superseded automatically. Majors stay separate (default `separateMajorMinor`) so breaking changes are still reviewed individually.

## Expected effect (once merged to `main`)

Open Renovate PRs drop from ~57 to ~15 and stay collapsed going forward.

## Follow-ups (intentionally not in this PR)

- Add a `pull_request`-triggered `helm lint`/`helm template` gate (nothing validates Renovate PRs today).
- Enable automerge for patch/digest bumps on internal `glueops/*` images once that CI gate exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)