### PR TITLE
fix: pin openbao podManagementPolicy for HA raft, use ghcr mirror

### DIFF
--- a/templates/application-external-secrets.yaml
+++ b/templates/application-external-secrets.yaml
@@ -31,7 +31,7 @@ spec:
     - "/spec/conversion/webhook/clientConfig/service/name"
     - "/spec/conversion/webhook/clientConfig/service/namespace"
   source:
-    repoURL: ghcr.io/external-secrets/charts
+    repoURL: {{ .Values.base_registries.ghcr_io }}/external-secrets/charts
     chart: external-secrets
     targetRevision: 0.19.2
     helm:

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -30,7 +30,7 @@ spec:
         - '.webhooks[0].clientConfig.caBundle'
       kind: MutatingWebhookConfiguration
   source:
-    repoURL: ghcr.io/openbao/charts
+    repoURL: {{ .Values.base_registries.ghcr_io }}/openbao/charts
     chart: openbao
     targetRevision: 0.19.3
     helm:
@@ -61,6 +61,14 @@ spec:
             repository: {{ .Values.container_images.app_vault.vault.image.repository }}
             tag: {{ .Values.container_images.app_vault.vault.image.tag }}
           updateStrategyType: "RollingUpdate"
+          # Pin podManagementPolicy explicitly. The chart default flipped from
+          # "Parallel" to "OrderedReady" in openbao chart 0.20.0, which breaks
+          # HA raft bootstrap (pods start one-at-a-time waiting for Ready, but a
+          # raft pod cannot become Ready until the cluster has quorum) and would
+          # collide with the immutable podManagementPolicy field on sync. Keeping
+          # it Parallel matches the current running StatefulSet, so this is a
+          # no-op today and lets the chart be upgraded past 0.20.0 safely.
+          podManagementPolicy: "Parallel"
           dataStorage:
             size: {{ .Values.vault.data_storage }}Gi
 


### PR DESCRIPTION
## Summary

Two changes to the OpenBao/vault and external-secrets Argo CD apps.

### 1. Pin `server.podManagementPolicy: Parallel` (vault) — HA raft safety

We run the openbao chart with `ha.enabled` and **3 raft replicas**. The chart's default `podManagementPolicy` flipped from `Parallel` to **`OrderedReady` in chart 0.20.0**. With `OrderedReady`, StatefulSet pods start one-at-a-time waiting for each to be `Ready` — but a raft pod can't become `Ready` until the cluster has quorum, so a multi-node bootstrap **deadlocks**. `podManagementPolicy` is also an **immutable** StatefulSet field, so the change would fail on sync (we use `ServerSideApply=true`, no `Replace`) and a forced fix would recreate all 3 raft pods at once.

We're currently on chart `0.19.3`, whose default is already `Parallel`, so pinning it explicitly is a **no-op on the running cluster today** — but it neutralizes the 0.20.0 default change and lets the chart be upgraded past 0.20.0 safely.

### 2. Use the ghcr mirror for OCI chart pulls

Point the openbao and external-secrets chart `repoURL`s at the org's ghcr mirror via `base_registries.ghcr_io` (`ghcr.repo.gpkg.io`) instead of hitting `ghcr.io` directly.

## Notes

- Renovate depNames for these charts change from `ghcr.io/...` to `ghcr.repo.gpkg.io/...`; Renovate will track the mirror path going forward (requires the mirror to expose the chart tags).
- `helm lint` + `helm template` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)