### PR TITLE
fix: namespacing of vpa/goldilocks to be prefixed with glueops-core-*

### DIFF
--- a/templates/application-goldilocks.yaml
+++ b/templates/application-goldilocks.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: goldilocks
+  name: glueops-core-goldilocks
   annotations:
     argocd.argoproj.io/sync-wave: "4"
   finalizers:

--- a/templates/application-vpa.yaml
+++ b/templates/application-vpa.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: vpa
+  name: glueops-core-vpa
   annotations:
     argocd.argoproj.io/sync-wave: "3"
   finalizers:


### PR DESCRIPTION
<img width="617" height="240" alt="Screenshot 2026-07-11 at 1 37 56 AM" src="https://github.com/user-attachments/assets/5cd38543-8883-47bd-88fe-08f54d503914" />
