### PR TITLE
feat: deploy argocd-extension-backend via the app chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This chart deploys the GlueOps Platform
 | certManager.aws_secretKey | string | `"placeholder_certmanager_aws_secret_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | container_images.app_argocd_extension_backend.argocd_extension_backend.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
 | container_images.app_argocd_extension_backend.argocd_extension_backend.image.repository | string | `"glueops/argocd-extension-backend-api"` |  |
-| container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag | string | `"v0.1.1"` |  |
+| container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag | string | `"v.0.0.1@sha256:fefde17e4a2223eea3a94ab4a864cfb40a340c6ce8b3b3ad578ef5a0154adfe3"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.repository | string | `"glueops/backup-tools"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.tag | string | `"v2.7.0@sha256:64e194438f3d056b4a658978be30cd06dce2d37e8df65db611b65aad0e7c3231"` |  |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This chart deploys the GlueOps Platform
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| argocd_extension_backend.grafana_apm_dashboard | string | `"opentelemetry-apm"` | UID of the OpenTelemetry APM dashboard shipped alongside the OTEL monitoring stack. Blank disables the link. |
+| argocd_extension_backend.grafana_k8s_overview_dashboard | string | `"ee58kcteeir5sf"` | UID of the Kubernetes Overview dashboard shipped alongside the OTEL monitoring stack. Blank disables the link. |
+| argocd_extension_backend.grafana_k8s_pod_dashboard | string | `"ce60j8f8umhhcc"` | UID of the Kubernetes Pod Overview dashboard shipped alongside the OTEL monitoring stack. Blank disables the link. |
+| argocd_extension_backend.grafana_loki_ds_uid | string | `""` | Loki datasource UID for Drilldown logs links. NOT pinned in provisioning: Grafana auto-generates it per cluster, so there is no correct shared default. Override per cluster with the real value (Grafana > Connections > Data sources > Loki, the uid in its URL). Left blank, logs fall back to the classic workload-logs dashboard, which still works. |
+| argocd_extension_backend.grafana_prometheus_ds_uid | string | `"prometheus"` | Prometheus datasource UID for Drilldown metrics links. Pinned explicitly in the monitoring chart's datasource provisioning, so it is identical on every cluster. |
+| argocd_extension_backend.grafana_tempo_ds_uid | string | `"de7lydl3hl9fkd"` | Tempo datasource UID for Drilldown traces links. Pinned explicitly in the monitoring chart's datasource provisioning, so it is identical on every cluster. |
 | base_registries.docker_io | string | `"dockerhub.repo.gpkg.io"` |  |
 | base_registries.ghcr_io | string | `"ghcr.repo.gpkg.io"` |  |
 | base_registries.public_ecr_aws | string | `"ecr.repo.gpkg.io"` |  |
@@ -21,7 +27,7 @@ This chart deploys the GlueOps Platform
 | certManager.aws_secretKey | string | `"placeholder_certmanager_aws_secret_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | container_images.app_argocd_extension_backend.argocd_extension_backend.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
 | container_images.app_argocd_extension_backend.argocd_extension_backend.image.repository | string | `"glueops/argocd-extension-backend-api"` |  |
-| container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag | string | `"v.0.0.1@sha256:fefde17e4a2223eea3a94ab4a864cfb40a340c6ce8b3b3ad578ef5a0154adfe3"` |  |
+| container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag | string | `"v0.1.4@sha256:e9f353fb7cb975474ca13594c5001f44c590fce6cf88baa665efb1e7f833290b"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.repository | string | `"glueops/backup-tools"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.tag | string | `"v2.7.0@sha256:64e194438f3d056b4a658978be30cd06dce2d37e8df65db611b65aad0e7c3231"` |  |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This chart deploys the GlueOps Platform
 | certManager.aws_accessKey | string | `"placeholder_certmanager_aws_access_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | certManager.aws_region | string | `"placeholder_aws_region"` | Should be the same `primary_region` you used in: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | certManager.aws_secretKey | string | `"placeholder_certmanager_aws_secret_key"` | Part of `certmanager_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
+| container_images.app_argocd_extension_backend.argocd_extension_backend.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
+| container_images.app_argocd_extension_backend.argocd_extension_backend.image.repository | string | `"glueops/argocd-extension-backend-api"` |  |
+| container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag | string | `"v0.1.1"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.registry | string | `"ghcr.repo.gpkg.io"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.repository | string | `"glueops/backup-tools"` |  |
 | container_images.app_backup_and_exports.backup_tools.image.tag | string | `"v2.7.0@sha256:64e194438f3d056b4a658978be30cd06dce2d37e8df65db611b65aad0e7c3231"` |  |

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -65,7 +65,7 @@ spec:
     helm:
       values: |
         appName: 'argocd-extension-backend-api'
-        appVersion: '0.0.1'
+        appVersion: '0.1.1'
 
         image:
           port: 8000

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -21,14 +21,11 @@ kind: Application
 metadata:
   name: glueops-argocd-extension-backend
   annotations:
-    # Ordered after captain-manifests (sync-wave 20), which owns the tenant
-    # environment namespace ($env) that the Role/RoleBinding below live in.
-    #
-    # This wave is a best-effort hint, NOT a guarantee: it gates on the
-    # captain-manifests Application reporting Healthy, which it already does
-    # whenever it is stale relative to its git source. So this app can still be
-    # created while $env does not yet exist. The retry budget below — not this
-    # annotation — is what makes that case recoverable.
+    # Kept after captain-manifests (sync-wave 20) as a soft ordering hint. This is
+    # no longer load-bearing: every resource this app creates now lives in either
+    # glueops-core (always present) or its own namespace, and the workload RBAC is
+    # cluster-scoped, so nothing here depends on the tenant environment namespace
+    # existing first. (It previously did, via a Role in $env — see the RBAC below.)
     argocd.argoproj.io/sync-wave: "21"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
@@ -44,17 +41,17 @@ spec:
     automated:
       prune: true
       selfHeal: true
-    # The RBAC below targets $env, a namespace owned by captain-manifests, so on a
-    # cold bootstrap this app can start syncing minutes before that namespace
-    # exists (observed gap: ~9m). Argo will not re-attempt a failed automated sync
-    # for an unchanged revision, so whatever this budget does not cover latches
-    # into a permanent SyncError. These values retry for ~17m before giving up.
+    # General resilience for transient apply failures. The namespace-ordering race
+    # that originally justified a large budget is gone (the workload RBAC is now
+    # cluster-scoped — see below), but Argo still will not re-attempt a failed
+    # automated sync for an unchanged revision, so a modest retry keeps a transient
+    # failure from latching into a permanent SyncError.
     retry:
       backoff:
         duration: 5s
         maxDuration: 3m0s
         factor: 2
-      limit: 10
+      limit: 5
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
@@ -222,6 +219,20 @@ spec:
               value: {{ $env | quote }}
             ALLOWED_NAMESPACES:
               value: {{ $env | quote }}
+            # Static links surfaced under the "Other" category (GlueOps-wide, not
+            # per-cluster). Pinned here rather than relying on the app's built-in
+            # defaults so the platform owns what shows up.
+            SUPPORT_URL:
+              value: "https://support.glueops.dev"
+            DOCUMENTATION_URL:
+              value: "https://docs.glueops.dev"
+            # Projects the extension does NOT serve: platform/core Applications carry
+            # project "glueops-core" (see the AppProject in argocd-projects-setup.yaml),
+            # so a link request for one returns an empty "not applicable" response. This
+            # replaces relying on ALLOWED_DEST_NAMESPACES to hide them, so it keeps
+            # working even if the destination allow-list is later widened.
+            SKIP_PROJECTS:
+              value: "glueops-core"
 
         # RBAC + NetworkPolicy are not first-class in the app chart, so they go through
         # customResources. Two templating phases apply: this platform chart (Helm)
@@ -284,13 +295,32 @@ spec:
               - kind: ServiceAccount
                 name: argocd-extension-backend-api
                 namespace: glueops-core-argocd-extension-backend
-          # Workload/ExternalSecret list: namespaced Role in the destination namespace.
+          # Workload/ExternalSecret/Pod list: CLUSTER-scoped, not a namespaced Role.
+          #
+          # This was a Role + RoleBinding in the destination namespace ($env), which
+          # is wrong on two counts:
+          #   1. Race: $env is owned by captain-manifests and often does not exist yet
+          #      when this app first syncs. `kubectl auth reconcile` resolves the
+          #      target namespace before applying, so the whole sync failed with
+          #      `namespaces "<env>" not found` until captain-manifests caught up.
+          #   2. Coverage: the backend serves whatever namespace an Application
+          #      deploys to, and that is not always $env. A Role pinned to one
+          #      namespace cannot authorize listing workloads in any other.
+          # A ClusterRole + ClusterRoleBinding removes the namespace dependency
+          # entirely, fixing both. The grant is now cluster-wide list on these
+          # resources; the backend still restricts what it actually reads to
+          # ALLOWED_DEST_NAMESPACES at the application layer, so effective exposure
+          # is unchanged even though the RBAC is broader.
+          #
+          # pods:list resolves one live pod name per workload to fill the Grafana POD
+          # Overview dashboard's var-pod. It is best-effort in the backend (a denied
+          # list is swallowed and the dashboard auto-selects a pod), so this grant
+          # only makes var-pod deep-links possible — it is not required to work.
           - |-
             apiVersion: rbac.authorization.k8s.io/v1
-            kind: Role
+            kind: ClusterRole
             metadata:
               name: argocd-extension-backend-api-workloads
-              namespace: {{ $env | quote }}
             rules:
               - apiGroups: ["apps"]
                 resources: ["deployments", "statefulsets", "daemonsets"]
@@ -298,15 +328,17 @@ spec:
               - apiGroups: ["external-secrets.io"]
                 resources: ["externalsecrets"]
                 verbs: ["list"]
+              - apiGroups: [""]
+                resources: ["pods"]
+                verbs: ["list"]
           - |-
             apiVersion: rbac.authorization.k8s.io/v1
-            kind: RoleBinding
+            kind: ClusterRoleBinding
             metadata:
               name: argocd-extension-backend-api-workloads
-              namespace: {{ $env | quote }}
             roleRef:
               apiGroup: rbac.authorization.k8s.io
-              kind: Role
+              kind: ClusterRole
               name: argocd-extension-backend-api-workloads
             subjects:
               - kind: ServiceAccount

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -1,0 +1,258 @@
+{{- /*
+Deploys the Argo CD UI extension backend (github.com/GlueOps/argo-cd-extention-backend)
+via the shared `app` chart, following the same pattern as the other platform
+components (see application-go-healthz.yaml / application-network-exporter.yaml).
+
+Cluster environment (e.g. "nonprod") is the first label of captain_domain and is
+used as the tenant destination namespace the backend serves.
+
+VERIFY BEFORE MERGE (namespace correction vs the standalone manifests):
+  The standalone chart/manifests in the backend repo scoped the app-namespace gate
+  and the NetworkPolicy source to a namespace literally named "argocd". On GlueOps
+  clusters Argo CD (server + Application CRs) runs in "glueops-core" (see the real
+  Application manifests, project glueops-core). This template therefore uses
+  glueops-core for both. If your Argo CD server actually runs elsewhere, adjust
+  `networkPolicyArgocdNamespace` and the ALLOWED_APP/ARGOCD_APP namespaces below.
+*/ -}}
+{{- $env := .Values.captain_domain | splitList "." | first -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: glueops-argocd-extension-backend
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    name: "in-cluster"
+    namespace: glueops-core-argocd-extension-backend
+  project: glueops-core
+  syncPolicy:
+    syncOptions:
+      - Replace=true
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      backoff:
+        duration: 5s
+        maxDuration: 3m0s
+        factor: 2
+      limit: 2
+  source:
+    repoURL: https://helm.gpkg.io/project-template
+    chart: app
+    targetRevision: 0.13.0
+    helm:
+      values: |
+        appName: 'argocd-extension-backend-api'
+        appVersion: '0.1.1'
+
+        image:
+          port: 8000
+          registry: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.registry }}
+          repository: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.repository }}
+          tag: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag }}
+          pullPolicy: IfNotPresent
+
+        serviceAccount:
+          create: true
+          name: argocd-extension-backend-api
+
+        service:
+          enabled: true
+          port: 8000
+
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
+
+        deployment:
+          {{- toYaml .Values.glueops_node_and_tolerations | nindent 10 }}
+          enabled: true
+          replicas: 2
+          imagePullPolicy: IfNotPresent
+          strategy: RollingUpdate
+          maxUnavailable: "0"
+          maxSurge: 1
+
+          serviceAccount:
+            enabled: true
+            automountServiceAccountToken: true
+
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+
+          containerSecurityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-extension-backend-api
+                  app.kubernetes.io/instance: glueops-argocd-extension-backend
+
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            failureThreshold: 30
+            periodSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+
+          volumes:
+            - name: tmp
+              emptyDir: {}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+
+          envMap:
+            PORT:
+              value: "8000"
+            LOG_LEVEL:
+              value: "INFO"
+            REQUEST_TIMEOUT_MS:
+              value: "8000"
+            TEMPO_SEARCH_PATH:
+              value: "/api/search"
+            TEMPO_BASE_URL:
+              value: ""
+            PROMETHEUS_BASE_URL:
+              value: "http://kps-prometheus.glueops-core-kube-prometheus-stack.svc.cluster.local:9090"
+            GRAFANA_BASE_URL:
+              value: "https://grafana.{{ .Values.captain_domain }}"
+            VAULT_BASE_URL:
+              value: "https://vault.{{ .Values.captain_domain }}"
+            DEPLOYMENT_CONFIG_REPO_URL:
+              value: "https://github.com/GlueOps/deployment-configurations"
+            CONFIG_REPO_LOCAL_ROOT:
+              value: ""
+            GRAFANA_LOGS_DASHBOARD:
+              value: ""
+            GRAFANA_METRICS_DASHBOARD:
+              value: ""
+            GRAFANA_TRACES_DASHBOARD:
+              value: ""
+            # Application CRs live in glueops-core (see VERIFY note above).
+            ARGOCD_APP_NAMESPACES:
+              value: "glueops-core"
+            ALLOWED_APP_NAMESPACES:
+              value: "glueops-core"
+            # Destination namespace this cluster's apps deploy into = the environment.
+            ALLOWED_DEST_NAMESPACES:
+              value: "{{ $env }}"
+            ALLOWED_NAMESPACES:
+              value: "{{ $env }}"
+
+        # RBAC + NetworkPolicy are not first-class in the app chart, so they go through
+        # customResources. Names/labels are LITERAL (the app chart's tpl runs on these
+        # but they contain no template expressions) — instance label = this Application's
+        # name (the Helm release name Argo CD uses).
+        customResources:
+          # NetworkPolicy: only argocd-server (in glueops-core) may reach the backend.
+          - |-
+            apiVersion: networking.k8s.io/v1
+            kind: NetworkPolicy
+            metadata:
+              name: argocd-extension-backend-api
+              namespace: glueops-core-argocd-extension-backend
+            spec:
+              podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-extension-backend-api
+                  app.kubernetes.io/instance: glueops-argocd-extension-backend
+              policyTypes:
+                - Ingress
+              ingress:
+                - from:
+                    - namespaceSelector:
+                        matchLabels:
+                          kubernetes.io/metadata.name: glueops-core
+                      podSelector:
+                        matchLabels:
+                          app.kubernetes.io/name: argocd-server
+                  ports:
+                    - protocol: TCP
+                      port: 8000
+          # argoproj.io Applications: get/list, CLUSTER-WIDE (always).
+          - |-
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRole
+            metadata:
+              name: argocd-extension-backend-api-applications
+            rules:
+              - apiGroups: ["argoproj.io"]
+                resources: ["applications"]
+                verbs: ["get", "list"]
+          - |-
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              name: argocd-extension-backend-api-applications
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: argocd-extension-backend-api-applications
+            subjects:
+              - kind: ServiceAccount
+                name: argocd-extension-backend-api
+                namespace: glueops-core-argocd-extension-backend
+          # Workload/ExternalSecret list: namespaced Role in the destination namespace.
+          - |-
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: argocd-extension-backend-api-workloads
+              namespace: {{ $env }}
+            rules:
+              - apiGroups: ["apps"]
+                resources: ["deployments", "statefulsets", "daemonsets"]
+                verbs: ["list"]
+              - apiGroups: ["external-secrets.io"]
+                resources: ["externalsecrets"]
+                verbs: ["list"]
+          - |-
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: RoleBinding
+            metadata:
+              name: argocd-extension-backend-api-workloads
+              namespace: {{ $env }}
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: Role
+              name: argocd-extension-backend-api-workloads
+            subjects:
+              - kind: ServiceAccount
+                name: argocd-extension-backend-api
+                namespace: glueops-core-argocd-extension-backend

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -19,6 +19,12 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: glueops-argocd-extension-backend
+  annotations:
+    # Sync after captain-manifests (sync-wave 20), which creates the tenant
+    # environment namespace ($env). The Role/RoleBinding below live in that
+    # namespace, so without this they can fail on the initial sync until the
+    # namespace exists.
+    argocd.argoproj.io/sync-wave: "21"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -52,7 +52,7 @@ spec:
     helm:
       values: |
         appName: 'argocd-extension-backend-api'
-        appVersion: '0.1.1'
+        appVersion: '0.0.1'
 
         image:
           port: 8000

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -252,7 +252,7 @@ spec:
             kind: Role
             metadata:
               name: argocd-extension-backend-api-workloads
-              namespace: {{ $env }}
+              namespace: {{ $env | quote }}
             rules:
               - apiGroups: ["apps"]
                 resources: ["deployments", "statefulsets", "daemonsets"]
@@ -265,7 +265,7 @@ spec:
             kind: RoleBinding
             metadata:
               name: argocd-extension-backend-api-workloads
-              namespace: {{ $env }}
+              namespace: {{ $env | quote }}
             roleRef:
               apiGroup: rbac.authorization.k8s.io
               kind: Role

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -13,7 +13,7 @@ Argo CD namespace assumption (correction vs the standalone manifests):
   Application manifests, project glueops-core), so this template uses glueops-core
   for both. If your Argo CD server runs elsewhere, change it in the two places
   below: the NetworkPolicy `namespaceSelector` (kubernetes.io/metadata.name:
-  glueops-core) and the ARGOCD_APP_NAMESPACES / ALLOWED_APP_NAMESPACES env vars.
+  glueops-core) and the ALLOWED_APP_NAMESPACES env var.
 */ -}}
 {{- $env := .Values.captain_domain | splitList "." | first -}}
 apiVersion: argoproj.io/v1alpha1
@@ -198,32 +198,30 @@ spec:
             # Prometheus and Tempo UIDs are pinned explicitly in the monitoring
             # chart's datasource provisioning, so they are the same everywhere.
             GRAFANA_PROMETHEUS_DS_UID:
-              value: "{{ .Values.argocd_extension_backend.grafana_prometheus_ds_uid }}"
+              value: {{ .Values.argocd_extension_backend.grafana_prometheus_ds_uid | quote }}
             GRAFANA_TEMPO_DS_UID:
-              value: "{{ .Values.argocd_extension_backend.grafana_tempo_ds_uid }}"
+              value: {{ .Values.argocd_extension_backend.grafana_tempo_ds_uid | quote }}
             # Loki is NOT provisioned with an explicit uid, so Grafana generates a
             # different one per cluster. There is no safe shared default: an
             # unset/wrong value here means logs keep using the classic dashboard
             # rather than linking to a datasource that does not exist.
             GRAFANA_LOKI_DS_UID:
-              value: "{{ .Values.argocd_extension_backend.grafana_loki_ds_uid }}"
+              value: {{ .Values.argocd_extension_backend.grafana_loki_ds_uid | quote }}
             # Platform dashboards shipped with the OTEL monitoring stack.
             GRAFANA_APM_DASHBOARD:
-              value: "{{ .Values.argocd_extension_backend.grafana_apm_dashboard }}"
+              value: {{ .Values.argocd_extension_backend.grafana_apm_dashboard | quote }}
             GRAFANA_K8S_OVERVIEW_DASHBOARD:
-              value: "{{ .Values.argocd_extension_backend.grafana_k8s_overview_dashboard }}"
+              value: {{ .Values.argocd_extension_backend.grafana_k8s_overview_dashboard | quote }}
             GRAFANA_K8S_POD_DASHBOARD:
-              value: "{{ .Values.argocd_extension_backend.grafana_k8s_pod_dashboard }}"
+              value: {{ .Values.argocd_extension_backend.grafana_k8s_pod_dashboard | quote }}
             # Application CRs live in glueops-core (see Argo CD namespace note above).
-            ARGOCD_APP_NAMESPACES:
-              value: "glueops-core"
             ALLOWED_APP_NAMESPACES:
               value: "glueops-core"
             # Destination namespace this cluster's apps deploy into = the environment.
             ALLOWED_DEST_NAMESPACES:
-              value: "{{ $env }}"
+              value: {{ $env | quote }}
             ALLOWED_NAMESPACES:
-              value: "{{ $env }}"
+              value: {{ $env | quote }}
 
         # RBAC + NetworkPolicy are not first-class in the app chart, so they go through
         # customResources. Two templating phases apply: this platform chart (Helm)

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -21,10 +21,14 @@ kind: Application
 metadata:
   name: glueops-argocd-extension-backend
   annotations:
-    # Sync after captain-manifests (sync-wave 20), which creates the tenant
-    # environment namespace ($env). The Role/RoleBinding below live in that
-    # namespace, so without this they can fail on the initial sync until the
-    # namespace exists.
+    # Ordered after captain-manifests (sync-wave 20), which owns the tenant
+    # environment namespace ($env) that the Role/RoleBinding below live in.
+    #
+    # This wave is a best-effort hint, NOT a guarantee: it gates on the
+    # captain-manifests Application reporting Healthy, which it already does
+    # whenever it is stale relative to its git source. So this app can still be
+    # created while $env does not yet exist. The retry budget below — not this
+    # annotation — is what makes that case recoverable.
     argocd.argoproj.io/sync-wave: "21"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
@@ -40,12 +44,17 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    # The RBAC below targets $env, a namespace owned by captain-manifests, so on a
+    # cold bootstrap this app can start syncing minutes before that namespace
+    # exists (observed gap: ~9m). Argo will not re-attempt a failed automated sync
+    # for an unchanged revision, so whatever this budget does not cover latches
+    # into a permanent SyncError. These values retry for ~17m before giving up.
     retry:
       backoff:
         duration: 5s
         maxDuration: 3m0s
         factor: 2
-      limit: 2
+      limit: 10
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -182,9 +182,11 @@ spec:
               value: "{{ $env }}"
 
         # RBAC + NetworkPolicy are not first-class in the app chart, so they go through
-        # customResources. Names/labels are LITERAL (the app chart's tpl runs on these
-        # but they contain no template expressions) — instance label = this Application's
-        # name (the Helm release name Argo CD uses).
+        # customResources. Two templating phases apply: this platform chart (Helm)
+        # renders its own expressions first (e.g. `{{ $env }}` below becomes a literal
+        # namespace), then the app chart runs `tpl` on the result. By that second phase
+        # the strings are already literal, so the app chart's `tpl` is a no-op here.
+        # Instance label = this Application's name (the Helm release name Argo CD uses).
         customResources:
           # NetworkPolicy: only argocd-server (in glueops-core) may reach the backend.
           - |-
@@ -211,24 +213,30 @@ spec:
                   ports:
                     - protocol: TCP
                       port: 8000
-          # argoproj.io Applications: get/list, CLUSTER-WIDE (always).
+          # argoproj.io Applications: get/list, scoped to glueops-core — where the
+          # Application CRs live (see ARGOCD_APP_NAMESPACES above). `applications` is a
+          # namespaced resource and the backend only reads from glueops-core, so a
+          # namespaced Role + RoleBinding is sufficient (least privilege, no cluster-wide
+          # grant). The bound ServiceAccount lives in the backend's own namespace.
           - |-
             apiVersion: rbac.authorization.k8s.io/v1
-            kind: ClusterRole
+            kind: Role
             metadata:
               name: argocd-extension-backend-api-applications
+              namespace: glueops-core
             rules:
               - apiGroups: ["argoproj.io"]
                 resources: ["applications"]
                 verbs: ["get", "list"]
           - |-
             apiVersion: rbac.authorization.k8s.io/v1
-            kind: ClusterRoleBinding
+            kind: RoleBinding
             metadata:
               name: argocd-extension-backend-api-applications
+              namespace: glueops-core
             roleRef:
               apiGroup: rbac.authorization.k8s.io
-              kind: ClusterRole
+              kind: Role
               name: argocd-extension-backend-api-applications
             subjects:
               - kind: ServiceAccount

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -72,9 +72,9 @@ spec:
 
         image:
           port: 8000
-          registry: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.registry }}
-          repository: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.repository }}
-          tag: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag }}
+          registry: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.registry | quote }}
+          repository: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.repository | quote }}
+          tag: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag | quote }}
           pullPolicy: IfNotPresent
 
         serviceAccount:
@@ -220,17 +220,22 @@ spec:
             ALLOWED_NAMESPACES:
               value: {{ $env | quote }}
             # Static links surfaced under the "Other" category (GlueOps-wide, not
-            # per-cluster). Pinned here rather than relying on the app's built-in
-            # defaults so the platform owns what shows up.
+            # per-cluster). Pinned here so the platform owns what shows up.
+            # FORWARD-COMPAT: the pinned image (v0.1.4) does not read these yet --
+            # they are implemented on the backend's fix/proxy-auth-and-hardening
+            # branch and take effect once the image is bumped to a release that
+            # includes it. Until then they are inert env vars.
             SUPPORT_URL:
               value: "https://support.glueops.dev"
             DOCUMENTATION_URL:
               value: "https://docs.glueops.dev"
             # Projects the extension does NOT serve: platform/core Applications carry
             # project "glueops-core" (see the AppProject in argocd-projects-setup.yaml),
-            # so a link request for one returns an empty "not applicable" response. This
-            # replaces relying on ALLOWED_DEST_NAMESPACES to hide them, so it keeps
-            # working even if the destination allow-list is later widened.
+            # so a link request for one returns an empty "not applicable" response.
+            # FORWARD-COMPAT: also not read by the pinned image (v0.1.4) -- same
+            # branch/bump as SUPPORT_URL above. Until that bump, platform apps are
+            # hidden solely by ALLOWED_DEST_NAMESPACES, so do NOT widen that
+            # allow-list expecting SKIP_PROJECTS to keep hiding them.
             SKIP_PROJECTS:
               value: "glueops-core"
 
@@ -267,7 +272,7 @@ spec:
                     - protocol: TCP
                       port: 8000
           # argoproj.io Applications: get/list, scoped to glueops-core — where the
-          # Application CRs live (see ARGOCD_APP_NAMESPACES above). `applications` is a
+          # Application CRs live (see ALLOWED_APP_NAMESPACES above). `applications` is a
           # namespaced resource and the backend only reads from glueops-core, so a
           # namespaced Role + RoleBinding is sufficient (least privilege, no cluster-wide
           # grant). The bound ServiceAccount lives in the backend's own namespace.

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -65,7 +65,13 @@ spec:
     helm:
       values: |
         appName: 'argocd-extension-backend-api'
-        appVersion: '0.1.2'
+        # DO NOT bump this to track the image version. The app chart feeds appVersion
+        # into chart.appLabels, which it uses as the Deployment's spec.selector --
+        # and selectors are IMMUTABLE. Changing this value makes every sync fail with
+        # "spec.selector: field is immutable" until the Deployment is manually
+        # deleted and recreated, on every cluster. The image tag in values.yaml is
+        # what identifies the running version; this is only a label.
+        appVersion: '0.0.1'
 
         image:
           port: 8000

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -6,14 +6,18 @@ components (see application-go-healthz.yaml / application-network-exporter.yaml)
 Cluster environment (e.g. "nonprod") is the first label of captain_domain and is
 used as the tenant destination namespace the backend serves.
 
-Argo CD namespace assumption (correction vs the standalone manifests):
-  The standalone chart/manifests in the backend repo scoped the app-namespace gate
-  and the NetworkPolicy source to a namespace literally named "argocd". On GlueOps
-  clusters Argo CD (server + Application CRs) runs in "glueops-core" (see the real
-  Application manifests, project glueops-core), so this template uses glueops-core
-  for both. If your Argo CD server runs elsewhere, change it in the two places
-  below: the NetworkPolicy `namespaceSelector` (kubernetes.io/metadata.name:
-  glueops-core) and the ALLOWED_APP_NAMESPACES env var.
+Argo CD namespace model (correction vs the standalone manifests):
+  The standalone chart/manifests in the backend repo assumed everything lives in a
+  namespace literally named "argocd". On GlueOps clusters argocd-server and the
+  PLATFORM Application CRs live in "glueops-core", but TENANT Application CRs —
+  the ones this extension exists to serve — live in the $env namespace via
+  apps-in-any-namespace: the tenant ApplicationSet stamps metadata.namespace =
+  $env, the tenant AppProject sets sourceNamespaces [$env], and argocd-server
+  runs with --application-namespaces=* (see the captain manifests repo). If your
+  layout differs, the namespace-coupled sites are the NetworkPolicy
+  `namespaceSelector` (where argocd-server runs) and the ALLOWED_APP_NAMESPACES
+  env var (where Application CRs live); the applications RBAC below is
+  cluster-scoped and needs no change.
 */ -}}
 {{- $env := .Values.captain_domain | splitList "." | first -}}
 apiVersion: argoproj.io/v1alpha1
@@ -57,7 +61,9 @@ spec:
     chart: app
     # Pinned to the same app-chart version as the other platform components
     # (application-go-healthz.yaml, application-network-exporter.yaml, …) to avoid
-    # version drift. Renders identically to 0.13.0 for these values (verified).
+    # version drift. Renders identically to 0.13.0 for these values (verified)
+    # except the helm.sh/chart labels/annotations, so a future bump is safe (no
+    # selector touches them) but will roll the pods once via the pod-template hash.
     targetRevision: 0.9.0
     helm:
       values: |
@@ -75,7 +81,6 @@ spec:
           registry: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.registry | quote }}
           repository: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.repository | quote }}
           tag: {{ .Values.container_images.app_argocd_extension_backend.argocd_extension_backend.image.tag | quote }}
-          pullPolicy: IfNotPresent
 
         serviceAccount:
           create: true
@@ -168,16 +173,34 @@ spec:
               value: "8000"
             TEMPO_SEARCH_PATH:
               value: "/api/search"
+            # Intentionally blank: the UI extension only ever calls /api/links, so
+            # the backend's Tempo search proxy has no callers — and GlueOps Tempo
+            # is multi-tenant (X-Scope-OrgID header) which the proxy does not send.
+            # Traces surface through the GRAFANA_TEMPO_DS_UID deep links instead.
             TEMPO_BASE_URL:
               value: ""
+            # Thanos query endpoint of the OTEL monitoring stack — the same target
+            # its Grafana datasource provisioning points at. kube-prometheus-stack
+            # (kps-prometheus) was removed by the OTEL migration this branch sits
+            # on, so do not point this back there. Only the backend's Prometheus
+            # proxy route reads this; the current UI extension never calls it.
             PROMETHEUS_BASE_URL:
-              value: "http://kps-prometheus.glueops-core-kube-prometheus-stack.svc.cluster.local:9090"
+              value: "http://glueops-core-thanos-query.glueops-core-monitoring.svc.cluster.local:9090"
             GRAFANA_BASE_URL:
               value: "https://grafana.{{ .Values.captain_domain }}"
             VAULT_BASE_URL:
               value: "https://vault.{{ .Values.captain_domain }}"
+            # The TENANT org's deployment-configurations repo. Tenant Application
+            # sources reference https://github.com/<tenant_github_org>/deployment-
+            # configurations, and the backend only reads value files whose source
+            # repoURL matches this env var exactly (identity gate) — pointing it at
+            # the GlueOps template repo would permanently disable config-derived
+            # Vault links. KNOWN LIMITATION: tenant repos are typically private and
+            # no GITHUB_TOKEN is wired (a token belongs in a secret, not envMap),
+            # so config-derived Vault links stay empty for private repos;
+            # live-ExternalSecret Vault links are unaffected.
             DEPLOYMENT_CONFIG_REPO_URL:
-              value: "https://github.com/GlueOps/deployment-configurations"
+              value: "https://github.com/{{ .Values.gitHub.tenant_github_org }}/deployment-configurations"
             CONFIG_REPO_LOCAL_ROOT:
               value: ""
             GRAFANA_LOGS_DASHBOARD:
@@ -211,12 +234,20 @@ spec:
               value: {{ .Values.argocd_extension_backend.grafana_k8s_overview_dashboard | quote }}
             GRAFANA_K8S_POD_DASHBOARD:
               value: {{ .Values.argocd_extension_backend.grafana_k8s_pod_dashboard | quote }}
-            # Application CRs live in glueops-core (see Argo CD namespace note above).
+            # Where Application CRs live (see the namespace model in the header):
+            # tenant CRs in $env, platform CRs in glueops-core. glueops-core is
+            # kept in the list so platform-app requests pass this gate and can hit
+            # the project-based SKIP_PROJECTS "not applicable" response once the
+            # image bump lands; until then the dest-namespace gate below hides them.
             ALLOWED_APP_NAMESPACES:
-              value: "glueops-core"
+              value: "glueops-core,{{ $env }}"
             # Destination namespace this cluster's apps deploy into = the environment.
             ALLOWED_DEST_NAMESPACES:
               value: {{ $env | quote }}
+            # Inert in v0.1.4: only the fallback default for the two vars above,
+            # which are both set explicitly. Kept fail-closed so any future gate
+            # that defaults to ALLOWED_NAMESPACES inherits $env rather than the
+            # backend's permissive '*' default.
             ALLOWED_NAMESPACES:
               value: {{ $env | quote }}
             # Static links surfaced under the "Other" category (GlueOps-wide, not
@@ -241,9 +272,9 @@ spec:
 
         # RBAC + NetworkPolicy are not first-class in the app chart, so they go through
         # customResources. Two templating phases apply: this platform chart (Helm)
-        # renders its own expressions first (e.g. `{{ $env }}` below becomes a literal
-        # namespace), then the app chart runs `tpl` on the result. By that second phase
-        # the strings are already literal, so the app chart's `tpl` is a no-op here.
+        # renders its own expressions first, then the app chart runs `tpl` on the
+        # result. The strings below are pure literals after phase one, so the app
+        # chart's `tpl` is a no-op here.
         # Instance label = this Application's name (the Helm release name Argo CD uses).
         customResources:
           # NetworkPolicy: only argocd-server (in glueops-core) may reach the backend.
@@ -271,36 +302,43 @@ spec:
                   ports:
                     - protocol: TCP
                       port: 8000
-          # argoproj.io Applications: get/list, scoped to glueops-core — where the
-          # Application CRs live (see ALLOWED_APP_NAMESPACES above). `applications` is a
-          # namespaced resource and the backend only reads from glueops-core, so a
-          # namespaced Role + RoleBinding is sufficient (least privilege, no cluster-wide
-          # grant). The bound ServiceAccount lives in the backend's own namespace.
+          # argoproj.io Applications: get, CLUSTER-scoped. The backend does a
+          # namespaced get of exactly the Application named in the request header,
+          # and those CRs live in TWO namespaces (tenant CRs in $env, platform CRs
+          # in glueops-core — see the header). A namespaced Role cannot span both,
+          # and a Role in $env would resurrect the captain-manifests namespace race
+          # described below, so this is a ClusterRole — with `get` only, which is
+          # strictly narrower than a cluster list: a caller must already know a
+          # CR's namespace AND name, so tenant Applications (and the helm values in
+          # their specs) cannot be enumerated. The backend's transient-failure
+          # fallback is a cluster-scope LIST (listClusterCustomObject) and stays
+          # intentionally unauthorized for exactly that enumeration reason; the
+          # cost is a degraded response (guessed workload names, no config/Vault
+          # links) on a transient get miss. The bound ServiceAccount lives in the
+          # backend's own namespace.
           - |-
             apiVersion: rbac.authorization.k8s.io/v1
-            kind: Role
+            kind: ClusterRole
             metadata:
               name: argocd-extension-backend-api-applications
-              namespace: glueops-core
             rules:
               - apiGroups: ["argoproj.io"]
                 resources: ["applications"]
-                verbs: ["get", "list"]
+                verbs: ["get"]
           - |-
             apiVersion: rbac.authorization.k8s.io/v1
-            kind: RoleBinding
+            kind: ClusterRoleBinding
             metadata:
               name: argocd-extension-backend-api-applications
-              namespace: glueops-core
             roleRef:
               apiGroup: rbac.authorization.k8s.io
-              kind: Role
+              kind: ClusterRole
               name: argocd-extension-backend-api-applications
             subjects:
               - kind: ServiceAccount
                 name: argocd-extension-backend-api
                 namespace: glueops-core-argocd-extension-backend
-          # Workload/ExternalSecret/Pod list: CLUSTER-scoped, not a namespaced Role.
+          # Workload/ExternalSecret list: CLUSTER-scoped, not a namespaced Role.
           #
           # This was a Role + RoleBinding in the destination namespace ($env), which
           # is wrong on two counts:
@@ -313,14 +351,21 @@ spec:
           #      namespace cannot authorize listing workloads in any other.
           # A ClusterRole + ClusterRoleBinding removes the namespace dependency
           # entirely, fixing both. The grant is now cluster-wide list on these
-          # resources; the backend still restricts what it actually reads to
-          # ALLOWED_DEST_NAMESPACES at the application layer, so effective exposure
-          # is unchanged even though the RBAC is broader.
+          # resources. The backend restricts reads to ALLOWED_DEST_NAMESPACES at the
+          # application layer, but only once the Application CR resolves: if the
+          # applications get fails transiently, v0.1.4 falls back to listing in the
+          # app-CR namespace from the request header without that gate — reads the
+          # old namespaced Role denied. Exposure there is workload names and Vault path
+          # links (never secret values; the SA has no `secrets` grant), accepted in
+          # exchange for killing the namespace race.
           #
-          # pods:list resolves one live pod name per workload to fill the Grafana POD
-          # Overview dashboard's var-pod. It is best-effort in the backend (a denied
-          # list is swallowed and the dashboard auto-selects a pod), so this grant
-          # only makes var-pod deep-links possible — it is not required to work.
+          # pods:list is intentionally NOT granted. The pinned image (v0.1.4) never
+          # lists pods — the var-pod resolution that wants it exists only on the
+          # backend's unreleased fix/proxy-auth-and-hardening branch (the same
+          # branch as SUPPORT_URL above). When bumping to a release that has it, add
+          #   - apiGroups: [""], resources: ["pods"], verbs: ["list"]
+          # back here; it is best-effort in the backend (a denied list is swallowed
+          # and the Grafana POD Overview dashboard auto-selects a pod).
           - |-
             apiVersion: rbac.authorization.k8s.io/v1
             kind: ClusterRole
@@ -332,9 +377,6 @@ spec:
                 verbs: ["list"]
               - apiGroups: ["external-secrets.io"]
                 resources: ["externalsecrets"]
-                verbs: ["list"]
-              - apiGroups: [""]
-                resources: ["pods"]
                 verbs: ["list"]
           - |-
             apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -65,7 +65,7 @@ spec:
     helm:
       values: |
         appName: 'argocd-extension-backend-api'
-        appVersion: '0.1.1'
+        appVersion: '0.1.2'
 
         image:
           port: 8000

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -6,13 +6,14 @@ components (see application-go-healthz.yaml / application-network-exporter.yaml)
 Cluster environment (e.g. "nonprod") is the first label of captain_domain and is
 used as the tenant destination namespace the backend serves.
 
-VERIFY BEFORE MERGE (namespace correction vs the standalone manifests):
+Argo CD namespace assumption (correction vs the standalone manifests):
   The standalone chart/manifests in the backend repo scoped the app-namespace gate
   and the NetworkPolicy source to a namespace literally named "argocd". On GlueOps
   clusters Argo CD (server + Application CRs) runs in "glueops-core" (see the real
-  Application manifests, project glueops-core). This template therefore uses
-  glueops-core for both. If your Argo CD server actually runs elsewhere, adjust
-  `networkPolicyArgocdNamespace` and the ALLOWED_APP/ARGOCD_APP namespaces below.
+  Application manifests, project glueops-core), so this template uses glueops-core
+  for both. If your Argo CD server runs elsewhere, change it in the two places
+  below: the NetworkPolicy `namespaceSelector` (kubernetes.io/metadata.name:
+  glueops-core) and the ARGOCD_APP_NAMESPACES / ALLOWED_APP_NAMESPACES env vars.
 */ -}}
 {{- $env := .Values.captain_domain | splitList "." | first -}}
 apiVersion: argoproj.io/v1alpha1
@@ -170,7 +171,7 @@ spec:
               value: ""
             GRAFANA_TRACES_DASHBOARD:
               value: ""
-            # Application CRs live in glueops-core (see VERIFY note above).
+            # Application CRs live in glueops-core (see Argo CD namespace note above).
             ARGOCD_APP_NAMESPACES:
               value: "glueops-core"
             ALLOWED_APP_NAMESPACES:

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -183,6 +183,31 @@ spec:
               value: ""
             GRAFANA_TRACES_DASHBOARD:
               value: ""
+            # --- Grafana Drilldown apps ---------------------------------------
+            # Setting a datasource UID switches that signal from its classic
+            # dashboard to the corresponding Drilldown app plugin. Blank it out to
+            # fall back, which is what a cluster not yet running the OTEL
+            # monitoring stack (and therefore without the plugins) should do.
+            #
+            # Prometheus and Tempo UIDs are pinned explicitly in the monitoring
+            # chart's datasource provisioning, so they are the same everywhere.
+            GRAFANA_PROMETHEUS_DS_UID:
+              value: "{{ .Values.argocd_extension_backend.grafana_prometheus_ds_uid }}"
+            GRAFANA_TEMPO_DS_UID:
+              value: "{{ .Values.argocd_extension_backend.grafana_tempo_ds_uid }}"
+            # Loki is NOT provisioned with an explicit uid, so Grafana generates a
+            # different one per cluster. There is no safe shared default: an
+            # unset/wrong value here means logs keep using the classic dashboard
+            # rather than linking to a datasource that does not exist.
+            GRAFANA_LOKI_DS_UID:
+              value: "{{ .Values.argocd_extension_backend.grafana_loki_ds_uid }}"
+            # Platform dashboards shipped with the OTEL monitoring stack.
+            GRAFANA_APM_DASHBOARD:
+              value: "{{ .Values.argocd_extension_backend.grafana_apm_dashboard }}"
+            GRAFANA_K8S_OVERVIEW_DASHBOARD:
+              value: "{{ .Values.argocd_extension_backend.grafana_k8s_overview_dashboard }}"
+            GRAFANA_K8S_POD_DASHBOARD:
+              value: "{{ .Values.argocd_extension_backend.grafana_k8s_pod_dashboard }}"
             # Application CRs live in glueops-core (see Argo CD namespace note above).
             ARGOCD_APP_NAMESPACES:
               value: "glueops-core"

--- a/templates/application-argocd-extension-backend.yaml
+++ b/templates/application-argocd-extension-backend.yaml
@@ -49,7 +49,10 @@ spec:
   source:
     repoURL: https://helm.gpkg.io/project-template
     chart: app
-    targetRevision: 0.13.0
+    # Pinned to the same app-chart version as the other platform components
+    # (application-go-healthz.yaml, application-network-exporter.yaml, …) to avoid
+    # version drift. Renders identically to 0.13.0 for these values (verified).
+    targetRevision: 0.9.0
     helm:
       values: |
         appName: 'argocd-extension-backend-api'

--- a/values.yaml
+++ b/values.yaml
@@ -370,7 +370,7 @@ container_images:
       image:
         registry: ghcr.repo.gpkg.io
         repository: glueops/argocd-extension-backend-api
-        tag: v0.1.3@sha256:73b420b4a75805f3a2ef112b6b067ca4dda205a868782b21294b48b518d0d025
+        tag: v0.1.4@sha256:e9f353fb7cb975474ca13594c5001f44c590fce6cf88baa665efb1e7f833290b
   app_cert_manager:
     cert_manager:
       image:

--- a/values.yaml
+++ b/values.yaml
@@ -349,7 +349,7 @@ container_images:
       image:
         registry: ghcr.repo.gpkg.io
         repository: glueops/argocd-extension-backend-api
-        tag: v0.1.1
+        tag: v.0.0.1@sha256:fefde17e4a2223eea3a94ab4a864cfb40a340c6ce8b3b3ad578ef5a0154adfe3
   app_cert_manager:
     cert_manager:
       image:

--- a/values.yaml
+++ b/values.yaml
@@ -349,7 +349,7 @@ container_images:
       image:
         registry: ghcr.repo.gpkg.io
         repository: glueops/argocd-extension-backend-api
-        tag: v.0.0.1@sha256:fefde17e4a2223eea3a94ab4a864cfb40a340c6ce8b3b3ad578ef5a0154adfe3
+        tag: v0.1.1@sha256:a73df0e7df8331ecdfb3d2a69a49fe7d90511ec58b15e6a9515ea33af98f6df3
   app_cert_manager:
     cert_manager:
       image:

--- a/values.yaml
+++ b/values.yaml
@@ -370,7 +370,7 @@ container_images:
       image:
         registry: ghcr.repo.gpkg.io
         repository: glueops/argocd-extension-backend-api
-        tag: v0.1.1@sha256:a73df0e7df8331ecdfb3d2a69a49fe7d90511ec58b15e6a9515ea33af98f6df3
+        tag: v0.1.2@sha256:ca8c865eccd595f3ea48c09c373b3b00d0a3503283ba01bb11b1f96c277316c9
   app_cert_manager:
     cert_manager:
       image:

--- a/values.yaml
+++ b/values.yaml
@@ -344,6 +344,12 @@ base_registries:
   registry_k8s_io: "k8s.repo.gpkg.io"
 
 container_images:
+  app_argocd_extension_backend:
+    argocd_extension_backend:
+      image:
+        registry: ghcr.repo.gpkg.io
+        repository: glueops/argocd-extension-backend-api
+        tag: v0.1.1
   app_cert_manager:
     cert_manager:
       image:

--- a/values.yaml
+++ b/values.yaml
@@ -343,6 +343,27 @@ base_registries:
   public_ecr_aws: "ecr.repo.gpkg.io"
   registry_k8s_io: "k8s.repo.gpkg.io"
 
+# Argo CD UI extension backend. These wire the Grafana links the extension renders.
+#
+# Setting a datasource UID switches that signal (logs/metrics/traces) from its
+# classic Grafana dashboard to the corresponding Drilldown app plugin. Leave a UID
+# blank on clusters that do not run the OTEL monitoring stack -- the Drilldown
+# plugins are not installed there, so a /a/<plugin>/ link would 404.
+argocd_extension_backend:
+  # Pinned explicitly in the monitoring chart's datasource provisioning, so these
+  # are stable across clusters.
+  grafana_prometheus_ds_uid: "prometheus"
+  grafana_tempo_ds_uid: "de7lydl3hl9fkd"
+  # NOT pinned in provisioning -- Grafana auto-generates Loki's uid per cluster, so
+  # there is no correct shared default. Override per cluster with the real value
+  # (Grafana > Connections > Data sources > Loki, the uid in its URL). Left blank,
+  # logs fall back to the classic workload-logs dashboard, which still works.
+  grafana_loki_ds_uid: ""
+  # Dashboards shipped alongside the OTEL monitoring stack. Blank disables the link.
+  grafana_apm_dashboard: "opentelemetry-apm"
+  grafana_k8s_overview_dashboard: "ee58kcteeir5sf"
+  grafana_k8s_pod_dashboard: "ce60j8f8umhhcc"
+
 container_images:
   app_argocd_extension_backend:
     argocd_extension_backend:

--- a/values.yaml
+++ b/values.yaml
@@ -370,7 +370,7 @@ container_images:
       image:
         registry: ghcr.repo.gpkg.io
         repository: glueops/argocd-extension-backend-api
-        tag: v0.1.2@sha256:ca8c865eccd595f3ea48c09c373b3b00d0a3503283ba01bb11b1f96c277316c9
+        tag: v0.1.3@sha256:73b420b4a75805f3a2ef112b6b067ca4dda205a868782b21294b48b518d0d025
   app_cert_manager:
     cert_manager:
       image:

--- a/values.yaml
+++ b/values.yaml
@@ -350,18 +350,17 @@ base_registries:
 # blank on clusters that do not run the OTEL monitoring stack -- the Drilldown
 # plugins are not installed there, so a /a/<plugin>/ link would 404.
 argocd_extension_backend:
-  # Pinned explicitly in the monitoring chart's datasource provisioning, so these
-  # are stable across clusters.
+  # -- Prometheus datasource UID for Drilldown metrics links. Pinned explicitly in the monitoring chart's datasource provisioning, so it is identical on every cluster.
   grafana_prometheus_ds_uid: "prometheus"
+  # -- Tempo datasource UID for Drilldown traces links. Pinned explicitly in the monitoring chart's datasource provisioning, so it is identical on every cluster.
   grafana_tempo_ds_uid: "de7lydl3hl9fkd"
-  # NOT pinned in provisioning -- Grafana auto-generates Loki's uid per cluster, so
-  # there is no correct shared default. Override per cluster with the real value
-  # (Grafana > Connections > Data sources > Loki, the uid in its URL). Left blank,
-  # logs fall back to the classic workload-logs dashboard, which still works.
+  # -- Loki datasource UID for Drilldown logs links. NOT pinned in provisioning: Grafana auto-generates it per cluster, so there is no correct shared default. Override per cluster with the real value (Grafana > Connections > Data sources > Loki, the uid in its URL). Left blank, logs fall back to the classic workload-logs dashboard, which still works.
   grafana_loki_ds_uid: ""
-  # Dashboards shipped alongside the OTEL monitoring stack. Blank disables the link.
+  # -- UID of the OpenTelemetry APM dashboard shipped alongside the OTEL monitoring stack. Blank disables the link.
   grafana_apm_dashboard: "opentelemetry-apm"
+  # -- UID of the Kubernetes Overview dashboard shipped alongside the OTEL monitoring stack. Blank disables the link.
   grafana_k8s_overview_dashboard: "ee58kcteeir5sf"
+  # -- UID of the Kubernetes Pod Overview dashboard shipped alongside the OTEL monitoring stack. Blank disables the link.
   grafana_k8s_pod_dashboard: "ce60j8f8umhhcc"
 
 container_images:


### PR DESCRIPTION
Deploys `argocd-extension-backend` via the shared app chart, rebased onto the monitoring/otel stack branch.

These commits were originally on `feat/argocd-extension-backend` (PR #1386, based on `main`). They are moved here so they sit on top of `feat/adding-monitoring-stack-updated-july-2026`, then hardened through several review rounds.

## Changes
- New `templates/application-argocd-extension-backend.yaml` — Argo CD Application using app-chart 0.9.0 with sync-wave annotation.
  - **Namespace model**: tenant Application CRs live in the `$env` namespace (apps-in-any-namespace), platform CRs in `glueops-core` — `ALLOWED_APP_NAMESPACES` covers both; `ALLOWED_DEST_NAMESPACES` limits serving to the tenant environment.
  - **RBAC (least privilege, verified against the pinned image's source)**: applications `get`-only ClusterRole (no list — tenant Application specs cannot be enumerated); workloads/externalsecrets `list` ClusterRole; no `pods` grant (unused by v0.1.4; re-add on the image bump that ships var-pod resolution).
  - **NetworkPolicy**: ingress restricted to argocd-server in `glueops-core`.
  - `PROMETHEUS_BASE_URL` targets the OTEL stack's Thanos query endpoint (kube-prometheus-stack was removed by the base branch); `DEPLOYMENT_CONFIG_REPO_URL` is templated from `gitHub.tenant_github_org` to match tenant Application sources.
  - `SUPPORT_URL` / `DOCUMENTATION_URL` / `SKIP_PROJECTS` are marked FORWARD-COMPAT: not read by the pinned v0.1.4 image, effective after the next backend release.
- `values.yaml` — pins the image to `v0.1.4` by digest under `container_images.app_argocd_extension_backend` (the template's `appVersion: 0.0.1` is only the immutable selector label); adds `argocd_extension_backend.*` Grafana UID knobs (Prometheus/Tempo UIDs and dashboard UIDs verified against the monitoring chart's datasource provisioning and the grafana-dashboards chart; Loki UID intentionally blank — it is auto-generated per cluster).
- `README.md` — helm-docs regeneration.

`helm lint` passes; the template was render-verified end-to-end through both templating phases (platform chart → inner values → app chart 0.9.0), and every env var was checked against the v0.1.4 backend source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
