### PR TITLE
feat: update glueops/vault-init-controller to v2.14.0 #minor

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -465,7 +465,7 @@ container_images:
       image:
         registry: ghcr.repo.gpkg.io
         repository: glueops/vault-init-controller
-        tag: v2.13.1@sha256:2eaa8b3099f543348270bf681c196c1bab899255a5074ecab9281fdbe65d6ccb
+        tag: v2.14.0@sha256:9b4d6ed77c3843c269846495b3f1f6f20e86cb8c92381727fcfb3d3169b0fbfa
   app_vault:
     vault:
       image:


### PR DESCRIPTION
Bumps `ghcr.repo.gpkg.io/glueops/vault-init-controller` from **v2.13.1 → v2.14.0** in `values.yaml`.

Manual bump standing in for Renovate: `v2.14.0` was released on the source repo today (2026-08-03 14:04:50Z) but the scheduled renovatebot run fired ~3 min later, before the new tag had propagated to the `ghcr.repo.gpkg.io` pull-through proxy, so no automatic PR was opened.

- Digest resolved from the gpkg.io proxy manifest for `v2.14.0`: `sha256:9b4d6ed77c3843c269846495b3f1f6f20e86cb8c92381727fcfb3d3169b0fbfa`
- Source release: https://github.com/GlueOps/vault-init-controller/releases/tag/v2.14.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)